### PR TITLE
Compile to v0.1.0b17

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Prior to calling this function you must call the `approve` method in `from`, aut
 
 ## Testing and Development
 
-**This contract is still under active development. It requires use of a pre-release version of the Vyper compiler. It has not been audited.**
+This project is written for compilation with Vyper [`0.1.0-beta17`](https://github.com/vyperlang/vyper/releases/tag/v0.1.0-beta.17).
 
 Unit testing and development of this project is performed using [Brownie](https://github.com/iamdefinitelyahuman/brownie).
 

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -474,6 +474,18 @@ def remove_pool(_pool: address):
 
 
 @public
+def set_returns_none(_addr: address, _is_returns_none: bool):
+    """
+    @notice Set `returns_none` value for a coin
+    @param _addr Coin address
+    @param _is_returns_none if True, coin returns None on a successful transfer
+    """
+    assert msg.sender == self.admin  # dev: admin-only function
+
+    self.returns_none[_addr] = _is_returns_none
+
+
+@public
 def set_gas_estimates(_addr: address[10], _amount: uint256[10]):
     """
     @notice Set gas estimate amounts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 eth-brownie>=1.8.6,<2.0.0
-
-### pre-release version of Vyper 0.2.0
-# once the actual version is released, this should be changed
--e git+git://github.com/vyperlang/vyper.git@1ebce95ed4fec4d96120d93df6f347799e8c7e02#egg=vyper
+vyper==0.1.0b17

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,15 @@ def isolation_setup(fn_isolation):
 # registries
 
 @pytest.fixture(scope="module")
-def registry(Registry, accounts):
-    yield Registry.deploy({'from': accounts[0]})
+def registry(Registry, accounts, USDT):
+    returns_none = [USDT, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+    yield Registry.deploy(returns_none, {'from': accounts[0]})
 
 
 @pytest.fixture(scope="module")
-def registry_compound(accounts, Registry, pool_compound, cDAI):
-    registry = Registry.deploy({'from': accounts[0]})
+def registry_compound(accounts, Registry, pool_compound, cDAI, USDT):
+    returns_none = [USDT, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+    registry = Registry.deploy(returns_none, {'from': accounts[0]})
     registry.add_pool(
         pool_compound,
         2,
@@ -32,8 +34,9 @@ def registry_compound(accounts, Registry, pool_compound, cDAI):
 
 
 @pytest.fixture(scope="module")
-def registry_y(Registry, accounts, pool_y, yDAI):
-    registry = Registry.deploy({'from': accounts[0]})
+def registry_y(Registry, accounts, pool_y, yDAI, USDT):
+    returns_none = [USDT, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+    registry = Registry.deploy(returns_none, {'from': accounts[0]})
     registry.add_pool(
         pool_y,
         4,
@@ -46,8 +49,9 @@ def registry_y(Registry, accounts, pool_y, yDAI):
 
 
 @pytest.fixture(scope="module")
-def registry_susd(Registry, accounts, pool_susd):
-    registry = Registry.deploy({'from': accounts[0]})
+def registry_susd(Registry, accounts, pool_susd, USDT):
+    returns_none = [USDT, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+    registry = Registry.deploy(returns_none, {'from': accounts[0]})
     registry.add_pool(
         pool_susd,
         4,
@@ -60,8 +64,9 @@ def registry_susd(Registry, accounts, pool_susd):
 
 
 @pytest.fixture(scope="module")
-def registry_all(Registry, accounts, pool_compound, pool_y, pool_susd, cDAI, yDAI):
-    registry = Registry.deploy({'from': accounts[0]})
+def registry_all(Registry, accounts, pool_compound, pool_y, pool_susd, cDAI, yDAI, USDT):
+    returns_none = [USDT, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+    registry = Registry.deploy(returns_none, {'from': accounts[0]})
 
     registry.add_pool(
         pool_compound,
@@ -94,20 +99,23 @@ def registry_all(Registry, accounts, pool_compound, pool_y, pool_susd, cDAI, yDA
 def pool_compound(PoolMock, accounts, DAI, USDC, cDAI, cUSDC):
     coins = [cDAI, cUSDC, ZERO_ADDRESS, ZERO_ADDRESS]
     underlying = [DAI, USDC, ZERO_ADDRESS, ZERO_ADDRESS]
-    yield PoolMock.deploy(2, coins, underlying, 70, 4000000, {'from': accounts[0]})
+    returns_none = [ZERO_ADDRESS] * 4
+    yield PoolMock.deploy(2, coins, underlying, returns_none, 70, 4000000, {'from': accounts[0]})
 
 
 @pytest.fixture(scope="module")
 def pool_y(PoolMock, accounts, DAI, USDC, USDT, TUSD, yDAI, yUSDC, yUSDT, yTUSD):
     coins = [yDAI, yUSDC, yUSDT, yTUSD]
     underlying = [DAI, USDC, USDT, TUSD]
-    yield PoolMock.deploy(4, coins, underlying, 70, 4000000, {'from': accounts[0]})
+    returns_none = [USDT, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+    yield PoolMock.deploy(4, coins, underlying, returns_none, 70, 4000000, {'from': accounts[0]})
 
 
 @pytest.fixture(scope="module")
 def pool_susd(PoolMock, accounts, DAI, USDC, USDT, sUSD):
     coins = [DAI, USDC, USDT, sUSD]
-    yield PoolMock.deploy(4, coins, coins, 70, 4000000, {'from': accounts[0]})
+    returns_none = [USDT, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+    yield PoolMock.deploy(4, coins, coins, returns_none, 70, 4000000, {'from': accounts[0]})
 
 
 # base stablecoins

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,11 +1,14 @@
 import brownie
 
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
 
 def test_admin_is_deployer(Registry, accounts):
-    registry = Registry.deploy({'from': accounts[0]})
+    returns_none = [ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS]
+    registry = Registry.deploy(returns_none, {'from': accounts[0]})
     assert registry.admin() == accounts[0]
 
-    registry = Registry.deploy({'from': accounts[1]})
+    registry = Registry.deploy(returns_none, {'from': accounts[1]})
     assert registry.admin() == accounts[1]
 
 

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -101,7 +101,8 @@ def test_same_token_underlying(accounts, registry_compound, pool_compound, cDAI)
 
 def test_token_returns_false(PoolMock, accounts, BAD, DAI, registry):
     coins = [DAI, BAD, ZERO_ADDRESS, ZERO_ADDRESS]
-    pool = PoolMock.deploy(2, coins, coins, 70, 4000000, {'from': accounts[0]})
+    returns_none = [ZERO_ADDRESS] * 4
+    pool = PoolMock.deploy(2, coins, coins, returns_none, 70, 4000000, {'from': accounts[0]})
     registry.add_pool(pool, 2, [18, 18, 0, 0, 0, 0, 0], b"", {'from': accounts[0]})
 
     DAI._mint_for_testing(10**18, {'from': accounts[0]})
@@ -124,7 +125,8 @@ def test_token_returns_false(PoolMock, accounts, BAD, DAI, registry):
 
 def test_token_returns_false_revert(PoolMock, accounts, BAD, DAI, registry):
     coins = [DAI, BAD, ZERO_ADDRESS, ZERO_ADDRESS]
-    pool = PoolMock.deploy(2, coins, coins, 70, 4000000, {'from': accounts[0]})
+    returns_none = [ZERO_ADDRESS] * 4
+    pool = PoolMock.deploy(2, coins, coins, returns_none, 70, 4000000, {'from': accounts[0]})
     registry.add_pool(pool, 2, [18, 18, 0, 0, 0, 0, 0], b"", {'from': accounts[0]})
 
     with brownie.reverts():

--- a/tests/test_get_pool_rates.py
+++ b/tests/test_get_pool_rates.py
@@ -3,33 +3,33 @@ import pytest
 
 
 def test_get_rates_compound(accounts, registry_compound, pool_compound, cDAI):
-    assert registry_compound.get_pool_rates(pool_compound) == [10**18, 10**18, 0, 0, 0, 0, 0]
+    assert registry_compound.get_pool_rates.call(pool_compound) == [10**18, 10**18, 0, 0, 0, 0, 0]
 
     cDAI._set_exchange_rate(31337, {'from': accounts[0]})
-    assert registry_compound.get_pool_rates(pool_compound) == [31337, 10**18, 0, 0, 0, 0, 0]
+    assert registry_compound.get_pool_rates.call(pool_compound) == [31337, 10**18, 0, 0, 0, 0, 0]
 
 
 def test_get_rates_y(accounts, registry_y, pool_y, yDAI):
-    assert registry_y.get_pool_rates(pool_y) == [10**18, 10**18, 10**18, 10**18, 0, 0, 0]
+    assert registry_y.get_pool_rates.call(pool_y) == [10**18, 10**18, 10**18, 10**18, 0, 0, 0]
 
     yDAI._set_exchange_rate(31337, {'from': accounts[0]})
-    assert registry_y.get_pool_rates(pool_y) == [31337, 10**18, 10**18, 10**18, 0, 0, 0]
+    assert registry_y.get_pool_rates.call(pool_y) == [31337, 10**18, 10**18, 10**18, 0, 0, 0]
 
 
 def test_pool_without_lending(accounts, registry_susd, pool_susd):
-    assert registry_susd.get_pool_rates(pool_susd) == [10**18, 10**18, 10**18, 10**18, 0, 0, 0]
+    assert registry_susd.get_pool_rates.call(pool_susd) == [10**18, 10**18, 10**18, 10**18, 0, 0, 0]
 
 
 def test_unknown_pool(accounts, registry):
-    assert registry.get_pool_rates(accounts[-1]) == [0, 0, 0, 0, 0, 0, 0]
+    assert registry.get_pool_rates.call(accounts[-1]) == [0, 0, 0, 0, 0, 0, 0]
 
 
 def test_removed_pool(accounts, registry_y, pool_y, yDAI):
     yDAI._set_exchange_rate(31337, {'from': accounts[0]})
-    assert registry_y.get_pool_rates(pool_y) == [31337, 10**18, 10**18, 10**18, 0, 0, 0]
+    assert registry_y.get_pool_rates.call(pool_y) == [31337, 10**18, 10**18, 10**18, 0, 0, 0]
 
     registry_y.remove_pool(pool_y)
-    assert registry_y.get_pool_rates(pool_y) == [0, 0, 0, 0, 0, 0, 0]
+    assert registry_y.get_pool_rates.call(pool_y) == [0, 0, 0, 0, 0, 0, 0]
 
 
 def test_fix_incorrect_calldata(accounts, registry, pool_compound, cDAI):
@@ -42,7 +42,7 @@ def test_fix_incorrect_calldata(accounts, registry, pool_compound, cDAI):
     )
 
     with brownie.reverts("dev: bad response"):
-        registry.get_pool_rates(pool_compound)
+        registry.get_pool_rates.call(pool_compound)
 
     registry.remove_pool(pool_compound)
     registry.add_pool(
@@ -53,4 +53,4 @@ def test_fix_incorrect_calldata(accounts, registry, pool_compound, cDAI):
         {'from': accounts[0]}
     )
 
-    assert registry.get_pool_rates(pool_compound) == [10**18, 10**18, 0, 0, 0, 0, 0]
+    assert registry.get_pool_rates.call(pool_compound) == [10**18, 10**18, 0, 0, 0, 0, 0]

--- a/tests/test_returns_none.py
+++ b/tests/test_returns_none.py
@@ -1,0 +1,19 @@
+import brownie
+
+def test_set_returns_none(accounts, registry_susd, pool_susd, USDT, DAI):
+    DAI._mint_for_testing(10**18, {'from': accounts[0]})
+    DAI.approve(registry_susd, 10**18, {'from': accounts[0]})
+
+    registry_susd.set_returns_none(USDT, False, {'from': accounts[0]})
+
+    with brownie.reverts():
+        registry_susd.exchange(pool_susd, DAI, USDT, 10**18, 0, {'from': accounts[0]})
+
+    registry_susd.set_returns_none(USDT, True, {'from': accounts[0]})
+
+    registry_susd.exchange(pool_susd, DAI, USDT, 10**18, 0, {'from': accounts[0]})
+
+
+def test_admin_only(accounts, registry, USDT):
+    with brownie.reverts("dev: admin-only function"):
+        registry.set_returns_none(USDT, False, {'from': accounts[1]})

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -19,7 +19,7 @@ class StateMachine:
     st_decimals = strategy('uint8[7]', max_value=42)
     st_amount = strategy('uint256', max_value=1e18)
 
-    def __init__(cls, PoolMock, accounts, registry, coins, underlying):
+    def __init__(cls, PoolMock, accounts, registry, coins, underlying, USDT):
         """
         Initial state machine setup.
 
@@ -35,18 +35,19 @@ class StateMachine:
 
         # create pools
         for i in range(3):
-            cls._create_pool(PoolMock, 2, coins[:2], underlying[:2])
+            cls._create_pool(PoolMock, 2, coins[:2], underlying[:2], USDT)
             coins.insert(0, coins.pop())
             underlying.insert(0, underlying.pop())
 
         for i in range(2):
-            cls._create_pool(PoolMock, 3, coins[:3], underlying[:3])
+            cls._create_pool(PoolMock, 3, coins[:3], underlying[:3], USDT)
             coins.insert(0, coins.pop())
             underlying.insert(0, underlying.pop())
-        cls._create_pool(PoolMock, 4, coins, underlying)
+
+        cls._create_pool(PoolMock, 4, coins, underlying, USDT)
 
     @classmethod
-    def _create_pool(cls, PoolMock, n_coins, coins, underlying):
+    def _create_pool(cls, PoolMock, n_coins, coins, underlying, USDT):
         # Create a pool and add it to `cls.pool_info`
         coins = coins + ([ZERO_ADDRESS] * (7-n_coins))
         underlying = underlying + ([ZERO_ADDRESS] * (7-n_coins))
@@ -55,6 +56,7 @@ class StateMachine:
             n_coins,
             coins[:4],
             underlying[:4],
+            [USDT, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS],
             70,
             4000000,
             {'from': cls.accounts[0]}
@@ -210,4 +212,4 @@ def test_state_machine(
     coins = [yDAI, yUSDC, yUSDT, yTUSD]
     underlying = [DAI, USDC, USDT, TUSD]
 
-    state_machine(StateMachine, PoolMock, accounts, registry, coins, underlying)
+    state_machine(StateMachine, PoolMock, accounts, registry, coins, underlying, USDT)


### PR DESCRIPTION
## What I did
Modify `Registry` to compile with Vyper `0.1.0-beta17`.

## How I did it
* Remove use of `empty` in favor of long array constants
* Remove use of `is_static_call` in `get_pool_rates` - we will have to tweak the ABI we distribute so that people are aware this method is meant to be called.
* Handle different ERC20 types using a new `returns_none` mapping, instead of relying on `raw_call`.
* Fix failing tests, add new test cases around `returns_none`

I have created a new branch [`vyper-v0.2.0`](https://github.com/curvefi/curve-pool-registry/tree/vyper-v0.2.0) to preserve the version that will compile to `v0.2.0`.

## How to verify it
Run the tests.