### PR TITLE
Expand gas estimation functionality

### DIFF
--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -90,7 +90,7 @@ pool_count: public(uint256)         # actual length of pool_list
 pool_data: map(address, PoolArray)
 returns_none: map(address, bool)
 
-gas_estimate_values: map(address, uint256)
+gas_estimate_values: map(address, uint256[2])
 gas_estimate_contracts: map(address, address)
 
 # mapping of coin -> coin -> pools for trading
@@ -247,29 +247,6 @@ def get_pool_rates(_pool: address) -> uint256[MAX_COINS]:
     return _rates
 
 
-@public
-@constant
-def estimate_gas_used(_pool: address, _from: address, _to: address) -> uint256:
-    """
-    @notice Estimate the gas used in an exchange.
-    @param _pool Pool address
-    @param _from Address of coin to be sent
-    @param _to Address of coin to be received
-    @return Upper-bound gas estimate, in wei
-    """
-    _total: uint256 = 0
-    _estimator: address = self.gas_estimate_contracts[_pool]
-    if _estimator != ZERO_ADDRESS:
-        return GasEstimator(_estimator).estimate_gas_used(_pool, _from, _to)
-
-    for _addr in [_from, _pool, _to]:
-        _gas: uint256 = self.gas_estimate_values[_addr]
-        assert _gas != 0  # dev: value not set
-        _total += _gas
-
-    return _total
-
-
 @private
 @constant
 def _get_token_indices(
@@ -318,6 +295,33 @@ def _get_token_indices(
             return i, j, True
 
     raise "No available market"
+
+
+@public
+@constant
+def estimate_gas_used(_pool: address, _from: address, _to: address) -> uint256:
+    """
+    @notice Estimate the gas used in an exchange.
+    @param _pool Pool address
+    @param _from Address of coin to be sent
+    @param _to Address of coin to be received
+    @return Upper-bound gas estimate, in wei
+    """
+    _total: uint256 = 0
+    _estimator: address = self.gas_estimate_contracts[_pool]
+    if _estimator != ZERO_ADDRESS:
+        return GasEstimator(_estimator).estimate_gas_used(_pool, _from, _to)
+
+    _idx: int128 = convert(self._get_token_indices(_pool, _from, _to)[2], int128)
+    _total = self.gas_estimate_values[_pool][_idx]
+    assert _total != 0  # dev: pool value not set
+
+    for _addr in [_from, _to]:
+        _gas: uint256 = self.gas_estimate_values[_addr][0]
+        assert _gas != 0  # dev: value not set
+        _total += _gas
+
+    return _total
 
 
 @public
@@ -856,11 +860,11 @@ def set_returns_none(_addr: address, _is_returns_none: bool):
 
 
 @public
-def set_gas_estimates(_addr: address[10], _amount: uint256[10]):
+def set_gas_estimates(_addr: address[10], _amount: uint256[2][10]):
     """
     @notice Set gas estimate amounts
     @param _addr Array of pool or coin addresses
-    @param _amount Array of gas estimate amounts
+    @param _amount Array of gas estimate amounts as `[(wrapped, underlying), ..]`
     """
     assert msg.sender == self.admin  # dev: admin-only function
 

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -860,10 +860,10 @@ def set_returns_none(_addr: address, _is_returns_none: bool):
 
 
 @public
-def set_gas_estimates(_addr: address[10], _amount: uint256[2][10]):
+def set_pool_gas_estimates(_addr: address[10], _amount: uint256[2][10]):
     """
     @notice Set gas estimate amounts
-    @param _addr Array of pool or coin addresses
+    @param _addr Array of pool addresses
     @param _amount Array of gas estimate amounts as `[(wrapped, underlying), ..]`
     """
     assert msg.sender == self.admin  # dev: admin-only function
@@ -872,6 +872,21 @@ def set_gas_estimates(_addr: address[10], _amount: uint256[2][10]):
         if _addr[i] == ZERO_ADDRESS:
             break
         self.gas_estimate_values[_addr[i]] = _amount[i]
+
+
+@public
+def set_coin_gas_estimates(_addr: address[10], _amount: uint256[10]):
+    """
+    @notice Set gas estimate amounts
+    @param _addr Array of coin addresses
+    @param _amount Array of gas estimate amounts
+    """
+    assert msg.sender == self.admin  # dev: admin-only function
+
+    for i in range(10):
+        if _addr[i] == ZERO_ADDRESS:
+            break
+        self.gas_estimate_values[_addr[i]][0] = _amount[i]
 
 
 @public

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -307,13 +307,12 @@ def estimate_gas_used(_pool: address, _from: address, _to: address) -> uint256:
     @param _to Address of coin to be received
     @return Upper-bound gas estimate, in wei
     """
-    _total: uint256 = 0
     _estimator: address = self.gas_estimate_contracts[_pool]
     if _estimator != ZERO_ADDRESS:
         return GasEstimator(_estimator).estimate_gas_used(_pool, _from, _to)
 
     _idx: int128 = convert(self._get_token_indices(_pool, _from, _to)[2], int128)
-    _total = self.gas_estimate_values[_pool][_idx]
+    _total: uint256 = self.gas_estimate_values[_pool][_idx]
     assert _total != 0  # dev: pool value not set
 
     for _addr in [_from, _to]:

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -318,7 +318,7 @@ def estimate_gas_used(_pool: address, _from: address, _to: address) -> uint256:
 
     for _addr in [_from, _to]:
         _gas: uint256 = self.gas_estimate_values[_addr][0]
-        assert _gas != 0  # dev: value not set
+        assert _gas != 0  # dev: coin value not set
         _total += _gas
 
     return _total
@@ -860,7 +860,7 @@ def set_returns_none(_addr: address, _is_returns_none: bool):
 
 
 @public
-def set_pool_gas_estimates(_addr: address[10], _amount: uint256[2][10]):
+def set_pool_gas_estimates(_addr: address[5], _amount: uint256[2][5]):
     """
     @notice Set gas estimate amounts
     @param _addr Array of pool addresses
@@ -868,7 +868,7 @@ def set_pool_gas_estimates(_addr: address[10], _amount: uint256[2][10]):
     """
     assert msg.sender == self.admin  # dev: admin-only function
 
-    for i in range(10):
+    for i in range(5):
         if _addr[i] == ZERO_ADDRESS:
             break
         self.gas_estimate_values[_addr[i]] = _amount[i]

--- a/tests/unitary/test_gas_estimates.py
+++ b/tests/unitary/test_gas_estimates.py
@@ -1,32 +1,44 @@
+import pytest
 import brownie
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
-def test_gas_estimates(accounts, registry, pool_susd, DAI, USDC, sUSD):
-    addr = [pool_susd, DAI, USDC, sUSD] + ([ZERO_ADDRESS] * 6)
-    registry.set_gas_estimates(addr, [1, 10, 100, 1000, 0, 0, 0, 0, 0, 0], {'from': accounts[0]})
+@pytest.fixture
+def set_estimates(accounts, registry_y, pool_y, DAI, USDC, USDT, yDAI, yUSDC, yUSDT):
+    addr = [DAI, USDC, USDT, yDAI, yUSDC, yUSDT] + [ZERO_ADDRESS] * 4
+    registry_y.set_coin_gas_estimates(addr, [10, 100, 1000, 20, 200, 2000, 0, 0, 0, 0], {'from': accounts[0]})
 
-    assert registry.estimate_gas_used(pool_susd, DAI, USDC) == 111
-    assert registry.estimate_gas_used(pool_susd, DAI, sUSD) == 1011
-
-
-def test_modify_estimates(accounts, registry, pool_susd, DAI, USDC, sUSD):
-    addr = [pool_susd, DAI, USDC, sUSD] + ([ZERO_ADDRESS] * 6)
-    registry.set_gas_estimates(addr, [1, 10, 100, 1000, 0, 0, 0, 0, 0, 0], {'from': accounts[0]})
-
-    addr = [sUSD, DAI] + ([ZERO_ADDRESS] * 8)
-    registry.set_gas_estimates(addr, [0, 9000, 0, 0, 0, 0, 0, 0, 0, 0], {'from': accounts[0]})
-
-    assert registry.estimate_gas_used(pool_susd, DAI, USDC) == 9101
-
-    with brownie.reverts("dev: value not set"):
-        registry.estimate_gas_used(pool_susd, DAI, sUSD)
+    addr = [pool_y] + [ZERO_ADDRESS] * 4
+    registry_y.set_pool_gas_estimates(addr, [[10000, 1]] + [[0, 0]] * 4, {'from': accounts[0]})
 
 
-def test_estimator_contract(accounts, registry, pool_susd, DAI, USDC, sUSD):
-    addr = [pool_susd, DAI, USDC, sUSD] + ([ZERO_ADDRESS] * 6)
-    registry.set_gas_estimates(addr, [1, 10, 100, 1000, 0, 0, 0, 0, 0, 0], {'from': accounts[0]})
+def test_gas_estimates_underlying(accounts, registry_y, pool_y, DAI, USDC, USDT, set_estimates):
+    assert registry_y.estimate_gas_used(pool_y, DAI, USDC) == 111
+    assert registry_y.estimate_gas_used(pool_y, DAI, USDT) == 1011
+
+
+def test_gas_estimates_wrapped(accounts, registry_y, pool_y, yDAI, yUSDC, yUSDT, set_estimates):
+    assert registry_y.estimate_gas_used(pool_y, yDAI, yUSDC) == 10220
+    assert registry_y.estimate_gas_used(pool_y, yDAI, yUSDT) == 12020
+
+
+def test_wrapped_against_underlying(accounts, registry_y, pool_y, DAI, yUSDC, set_estimates):
+    with brownie.reverts("No available market"):
+        registry_y.estimate_gas_used(pool_y, DAI, yUSDC) == 10220
+
+
+def test_modify_estimates(accounts, registry_y, pool_y, DAI, USDC, USDT, set_estimates):
+    addr = [USDT, DAI] + ([ZERO_ADDRESS] * 8)
+    registry_y.set_coin_gas_estimates(addr, [0, 9000, 0, 0, 0, 0, 0, 0, 0, 0], {'from': accounts[0]})
+
+    assert registry_y.estimate_gas_used(pool_y, DAI, USDC) == 9101
+
+    with brownie.reverts("dev: coin value not set"):
+        registry_y.estimate_gas_used(pool_y, DAI, USDT)
+
+
+def test_estimator_contract(accounts, registry_y, pool_y, DAI, USDC, set_estimates):
 
     estimator = brownie.compile_source("""
 @public
@@ -35,29 +47,71 @@ def estimate_gas_used(_pool: address, _from: address, _to: address) -> uint256:
     """).Vyper.deploy({'from': accounts[0]})
 
 
-    assert registry.estimate_gas_used(pool_susd, DAI, USDC) == 111
+    assert registry_y.estimate_gas_used(pool_y, DAI, USDC) == 111
 
-    registry.set_gas_estimate_contract(pool_susd, estimator, {'from': accounts[0]})
-    assert registry.estimate_gas_used(pool_susd, DAI, USDC) == 31337
+    registry_y.set_gas_estimate_contract(pool_y, estimator, {'from': accounts[0]})
+    assert registry_y.estimate_gas_used(pool_y, DAI, USDC) == 31337
 
-    registry.set_gas_estimate_contract(pool_susd, ZERO_ADDRESS, {'from': accounts[0]})
-    assert registry.estimate_gas_used(pool_susd, DAI, USDC) == 111
-
-
-def test_no_value_set(registry, pool_susd, DAI, USDC):
-    with brownie.reverts("dev: value not set"):
-        registry.estimate_gas_used(pool_susd, DAI, USDC)
+    registry_y.set_gas_estimate_contract(pool_y, ZERO_ADDRESS, {'from': accounts[0]})
+    assert registry_y.estimate_gas_used(pool_y, DAI, USDC) == 111
 
 
-def test_admin_only(accounts, registry):
+def test_no_pool_value_set(accounts, registry_y, pool_y, DAI, USDC):
+    addr = [DAI, USDC] + ([ZERO_ADDRESS] * 8)
+    registry_y.set_coin_gas_estimates(addr, [100, 1000, 0, 0, 0, 0, 0, 0, 0, 0], {'from': accounts[0]})
+
+    with brownie.reverts("dev: pool value not set"):
+        registry_y.estimate_gas_used(pool_y, DAI, USDC)
+
+
+def test_no_underlying_pool_value_set(accounts, registry_y, pool_y, DAI, USDC):
+    addr = [DAI, USDC] + ([ZERO_ADDRESS] * 8)
+    registry_y.set_coin_gas_estimates(addr, [100, 1000, 0, 0, 0, 0, 0, 0, 0, 0], {'from': accounts[0]})
+
+    addr = [pool_y] + [ZERO_ADDRESS] * 4
+    registry_y.set_pool_gas_estimates(addr, [[1, 0]] + [[0, 0]] * 4, {'from': accounts[0]})
+
+    with brownie.reverts("dev: pool value not set"):
+        registry_y.estimate_gas_used(pool_y, DAI, USDC)
+
+
+def test_no_wrapped_pool_value_set(accounts, registry_y, pool_y, yDAI, yUSDC):
+    addr = [yDAI, yUSDC] + ([ZERO_ADDRESS] * 8)
+    registry_y.set_coin_gas_estimates(addr, [100, 1000, 0, 0, 0, 0, 0, 0, 0, 0], {'from': accounts[0]})
+
+    addr = [pool_y] + [ZERO_ADDRESS] * 4
+    registry_y.set_pool_gas_estimates(addr, [[0, 1]] + [[0, 0]] * 4, {'from': accounts[0]})
+
+    with brownie.reverts("dev: pool value not set"):
+        registry_y.estimate_gas_used(pool_y, yDAI, yUSDC)
+
+
+def test_no_coin_value_set(accounts, registry_y, pool_y, DAI, USDC):
+    addr = [pool_y] + [ZERO_ADDRESS] * 4
+    registry_y.set_pool_gas_estimates(addr, [[1,1]] + [[0, 0]] * 4, {'from': accounts[0]})
+
+    with brownie.reverts("dev: coin value not set"):
+        registry_y.estimate_gas_used(pool_y, DAI, USDC)
+
+
+def test_set_coin_admin_only(accounts, registry_y):
     with brownie.reverts("dev: admin-only function"):
-        registry.set_gas_estimates(
+        registry_y.set_coin_gas_estimates(
             [ZERO_ADDRESS] * 10,
             [0] * 10,
             {'from': accounts[1]}
         )
 
 
-def test_admin_only_estimator(accounts, registry):
+def test_set_pool_admin_only(accounts, registry_y):
     with brownie.reverts("dev: admin-only function"):
-        registry.set_gas_estimate_contract(ZERO_ADDRESS, ZERO_ADDRESS, {'from': accounts[1]})
+        registry_y.set_pool_gas_estimates(
+            [ZERO_ADDRESS] * 5,
+            [[0,0]] * 5,
+            {'from': accounts[1]}
+        )
+
+
+def test_admin_only_estimator(accounts, registry_y):
+    with brownie.reverts("dev: admin-only function"):
+        registry_y.set_gas_estimate_contract(ZERO_ADDRESS, ZERO_ADDRESS, {'from': accounts[1]})


### PR DESCRIPTION
## What I did
Expand gas estimation logic to differentiate between transfers of wrapped coins or underlying coins. This also has a side effect of verifying the correctness of all gas estimates - if the given pool doesn't support trades between the given coins, the call fails.

## How I did it
* Split the `set_gas_estimates` function into `set_coin_gas_estimates` and `set_pool_gas_estimates`. The 2nd function takes a multidimensional array where each item is `[wrapped exchange cost, underlying exchange cost]`
* In `estimate_gas_used`, call to `_get_token_indices` to check if the exchange will involve wrapped or underlying coins.

## How to verify
Run tests.