### PR TITLE
Expand pool info

### DIFF
--- a/contracts/testing/PoolMock.vy
+++ b/contracts/testing/PoolMock.vy
@@ -16,7 +16,15 @@ coin_list: address[4]
 underlying_coin_list: address[4]
 
 A: public(uint256)
+initial_A: public(uint256)
+initial_A_time: public(uint256)
+future_A: public(uint256)
+future_A_time: public(uint256)
+
 fee: public(uint256)
+future_fee: public(uint256)
+future_admin_fee: public(uint256)
+future_owner: public(address)
 
 
 @external
@@ -152,14 +160,31 @@ def exchange_underlying(i: int128, j: int128, dx: uint256, min_dy: uint256):
 # testing functions
 
 @external
-def _set_A(_value: uint256):
-    self.A = _value
+def _set_A(
+    _A: uint256,
+    _initial_A: uint256,
+    _initial_A_time: uint256,
+    _future_A: uint256,
+    _future_A_time: uint256
+):
+    self.A = _A
+    self.initial_A = _initial_A
+    self.initial_A_time = _initial_A_time
+    self.future_A = _future_A
+    self.future_A_time = _future_A_time
 
 
 @external
-def _set_fee(_value: uint256):
-    self.fee = _value
-
+def _set_fees_and_owner(
+    _fee: uint256,
+    _future_fee: uint256,
+    _future_admin_fee: uint256,
+    _future_owner: address
+):
+    self.fee = _fee
+    self.future_fee = _future_fee
+    self.future_admin_fee = _future_admin_fee
+    self.future_owner = _future_owner
 
 @external
 @payable

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -12,7 +12,6 @@ DEPLOYER_DEST = "0xC447FcAF1dEf19A583F97b3620627BF69c05b5fB"
 POA = False
 USE_MIDDLEWARE = True
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
-TETHERS = ["0xdAC17F958D2ee523a2206206994597C13D831ec7"] + [ZERO_ADDRESS] * 3
 MAX_COINS = 8
 EMPTY_DECIMALS = pack_values([0] * MAX_COINS)
 CONFS = 10
@@ -27,38 +26,40 @@ def insert_calculator(params, calculator):
 POOLS = [
     (  # Compound
         '0xA2B47E3D5c44877cca798226B7B8118F9BFb7A56', 2, '0x845838DF265Dcd2c412A1Dc9e959c7d08537f8a2',
-        right_pad(cERC20.signatures['exchangeRateStored']), EMPTY_DECIMALS, EMPTY_DECIMALS,
+        right_pad(cERC20.signatures['exchangeRateStored']), EMPTY_DECIMALS, EMPTY_DECIMALS, False,
     ),
     (  # USDT
         '0x52EA46506B9CC5Ef470C5bf89f17Dc28bB35D85C', 3, '0x9fC689CCaDa600B6DF723D9E47D84d76664a1F23',
-        right_pad(cERC20.signatures['exchangeRateStored']), EMPTY_DECIMALS, EMPTY_DECIMALS,
+        right_pad(cERC20.signatures['exchangeRateStored']), EMPTY_DECIMALS, EMPTY_DECIMALS, False,
     ),
     (  # Y
         '0x45F783CCE6B7FF23B2ab2D70e416cdb7D6055f51', 4, '0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8',
-        right_pad(yERC20.signatures['getPricePerFullShare']), EMPTY_DECIMALS, EMPTY_DECIMALS,
+        right_pad(yERC20.signatures['getPricePerFullShare']), EMPTY_DECIMALS, EMPTY_DECIMALS, False,
     ),
     (  # BUSD
         '0x79a8C46DeA5aDa233ABaFFD40F3A0A2B1e5A4F27', 4, '0x3B3Ac5386837Dc563660FB6a0937DFAa5924333B',
-        right_pad(yERC20.signatures['getPricePerFullShare']), EMPTY_DECIMALS, EMPTY_DECIMALS,
+        right_pad(yERC20.signatures['getPricePerFullShare']), EMPTY_DECIMALS, EMPTY_DECIMALS, False,
     ),
     (  # SUSD
         '0xA5407eAE9Ba41422680e2e00537571bcC53efBfD', 4, '0xC25a3A3b969415c80451098fa907EC722572917F',
-        "0x00", EMPTY_DECIMALS, EMPTY_DECIMALS,
+        "0x00", EMPTY_DECIMALS, EMPTY_DECIMALS, False,
     ),
     (  # PAX
         '0x06364f10B501e868329afBc005b3492902d6C763', 4, '0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8',
-        right_pad(yERC20.signatures['getPricePerFullShare']), EMPTY_DECIMALS, EMPTY_DECIMALS
+        right_pad(yERC20.signatures['getPricePerFullShare']), EMPTY_DECIMALS, EMPTY_DECIMALS, True,
     ),
 ]
 
 POOLS_NO_UNDERLYING = [
     (  # RenBTC
         '0x93054188d876f558f4a66B2EF1d97d16eDf0895B', 2, '0x49849C98ae39Fff122806C06791Fa73784FB3675',
-        right_pad(cERC20.signatures['exchangeRateCurrent']), EMPTY_DECIMALS, pack_values([True] + [False] * 7)
+        right_pad(cERC20.signatures['exchangeRateCurrent']), EMPTY_DECIMALS, pack_values([True] + [False] * 7),
+        True,
     ),
     (  # SBTC
         '0x7fC77b5c7614E1533320Ea6DDc2Eb61fa00A9714', 3, '0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3',
-        right_pad(cERC20.signatures['exchangeRateCurrent']), EMPTY_DECIMALS, pack_values([True] + [False] * 7)
+        right_pad(cERC20.signatures['exchangeRateCurrent']), EMPTY_DECIMALS, pack_values([True] + [False] * 7),
+        True,
     ),
 ]
 
@@ -122,7 +123,7 @@ def main(deployment_address=DEPLOYER):
         sleep(5)
         while True:
             try:
-                registry = Registry.deploy(TETHERS, deployer_kwargs)
+                registry = Registry.deploy(deployer_kwargs)
             except KeyError:
                 continue
             break

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ def registry_compound(accounts, Registry, pool_compound, calculator, lp_compound
         right_pad(cDAI.exchangeRateStored.signature),
         pack_values([8, 8]),
         pack_values([18, 6]),
+        True,
         {'from': accounts[0]}
     )
 
@@ -47,6 +48,7 @@ def registry_y(Registry, accounts, pool_y, calculator, lp_y, yDAI, USDT):
         right_pad(yDAI.getPricePerFullShare.signature),
         pack_values([18, 6, 6, 18]),
         pack_values([18, 6, 6, 18]),
+        True,
         {'from': accounts[0]}
     )
 
@@ -64,6 +66,7 @@ def registry_susd(Registry, accounts, pool_susd, calculator, lp_susd, USDT):
         "0x00",
         pack_values([18, 6, 6, 18]),
         pack_values([18, 6, 6, 18]),
+        True,
         {'from': accounts[0]}
     )
 
@@ -81,6 +84,7 @@ def registry_eth(Registry, accounts, pool_eth, lp_y, USDT, yDAI):
         right_pad(yDAI.getPricePerFullShare.signature),
         "0x00",
         "0x00",
+        True,
         {'from': accounts[0]}
     )
 
@@ -104,6 +108,7 @@ def registry_all(
         right_pad(cDAI.exchangeRateStored.signature),
         pack_values([8, 8]),
         pack_values([18, 6]),
+        True,
         {'from': accounts[0]}
     )
     registry.add_pool(
@@ -114,6 +119,7 @@ def registry_all(
         right_pad(yDAI.getPricePerFullShare.signature),
         pack_values([18, 6, 6, 18]),
         pack_values([18, 6, 6, 18]),
+        True,
         {'from': accounts[0]}
     )
     registry.add_pool(
@@ -124,6 +130,7 @@ def registry_all(
         "0x00",
         pack_values([18, 6, 6, 18]),
         pack_values([18, 6, 6, 18]),
+        True,
         {'from': accounts[0]}
     )
 

--- a/tests/forked/conftest.py
+++ b/tests/forked/conftest.py
@@ -32,6 +32,7 @@ def registry_renbtc(accounts, registry, calculator, pool_renbtc, lp_renbtc):
         right_pad("0xbd6d894d"),
         pack_values([8, 8]),
         pack_values([True] + [False] * 7),
+        True,
         {'from': accounts[0]}
     )
 

--- a/tests/integration/test_stateful.py
+++ b/tests/integration/test_stateful.py
@@ -93,6 +93,7 @@ class StateMachine:
                     "0x00",
                     "0x00",
                     "0x00",
+                    True,
                     {'from': self.accounts[0]}
                 )
         else:
@@ -107,6 +108,7 @@ class StateMachine:
                 "0x00",
                 pack_values(decimals),
                 pack_values(udecimals),
+                True,
                 {'from': self.accounts[0]}
             )
             self.added_pools.add(st_pool)

--- a/tests/unitary/test_add_pool.py
+++ b/tests/unitary/test_add_pool.py
@@ -37,6 +37,7 @@ def test_admin_only(accounts, registry, pool_compound, lp_compound):
             "0x00",
             pack_values([8, 8]),
             pack_values([18, 6]),
+            True,
             {'from': accounts[1]}
         )
 
@@ -51,6 +52,7 @@ def test_cannot_add_twice(accounts, registry_compound, pool_compound, lp_compoun
             "0x00",
             pack_values([8, 8]),
             pack_values([18, 6]),
+            True,
             {'from': accounts[0]}
         )
 
@@ -65,6 +67,7 @@ def test_add_multiple(accounts, registry, pool_y, pool_susd, lp_y):
             "0x00",
             pack_values([18, 6, 6, 18]),
             pack_values([1, 2, 3, 4]),
+            True,
             {'from': accounts[0]}
         )
 
@@ -90,6 +93,7 @@ def test_get_pool_info(accounts, registry, pool_y, pool_susd, lp_y, lp_susd, yDA
         right_pad(yDAI.getPricePerFullShare.signature),
         pack_values([1, 2, 3, 4]),
         pack_values([9, 8, 7, 6]),
+        True,
         {'from': accounts[0]}
     )
     y_pool_info = registry.get_pool_info(pool_y)
@@ -102,6 +106,7 @@ def test_get_pool_info(accounts, registry, pool_y, pool_susd, lp_y, lp_susd, yDA
         "0x00",
         pack_values([33, 44, 55, 66]),
         pack_values([99, 88, 77, 22]),
+        True,
         {'from': accounts[0]}
     )
     susd_pool_info = registry.get_pool_info(pool_susd)
@@ -118,6 +123,7 @@ def test_fetch_decimals(accounts, registry, pool_y, lp_y):
         "0x00",
         "0x00",
         "0x00",
+        True,
         {'from': accounts[0]}
     )
     assert registry.get_pool_coins(pool_y)['underlying_decimals'] == [18, 6, 6, 18, 0, 0, 0, 0]
@@ -138,6 +144,7 @@ def test_decimal_overflows_via_fetch(accounts, registry, DAI, ERC20, PoolMock):
             "0x00",
             "0x00",
             "0x00",
+            True,
             {'from': accounts[0]}
         )
 
@@ -151,6 +158,7 @@ def test_without_underlying(accounts, registry, pool_compound, cDAI, cUSDC):
         "0x00",
         pack_values([8, 8]),
         pack_values([True] + [False] * 7),
+        True,
         {'from': accounts[0]}
     )
     coin_info = registry.get_pool_coins(pool_compound)
@@ -170,6 +178,7 @@ def test_without_underlying_admin_only(accounts, registry, pool_compound):
             "0x00",
             pack_values([8, 8]),
             pack_values([True] + [False] * 7),
+            True,
             {'from': accounts[1]}
         )
 
@@ -184,5 +193,6 @@ def test_without_underlying_already_exists(accounts, registry_compound, pool_com
             "0x00",
             pack_values([8, 8]),
             pack_values([True] + [False] * 7),
+            True,
             {'from': accounts[0]}
         )

--- a/tests/unitary/test_exchange.py
+++ b/tests/unitary/test_exchange.py
@@ -80,6 +80,7 @@ def test_min_dy(accounts, registry, pool_compound, lp_compound, DAI, USDC):
         "0x00",
         pack_values([8, 8]),
         pack_values([18, 6]),
+        True,
         {'from': accounts[0]}
     )
     DAI._mint_for_testing(10**18, {'from': accounts[0]})
@@ -115,6 +116,7 @@ def test_token_returns_false(PoolMock, accounts, BAD, DAI, registry):
         "0x00",
         pack_values([18, 18]),
         pack_values([18, 18]),
+        True,
         {'from': accounts[0]}
     )
 
@@ -147,6 +149,7 @@ def test_token_returns_false_revert(PoolMock, accounts, BAD, DAI, registry):
         "0x00",
         pack_values([18, 18]),
         pack_values([18, 18]),
+        True,
         {'from': accounts[0]}
     )
 

--- a/tests/unitary/test_get_pool_rates.py
+++ b/tests/unitary/test_get_pool_rates.py
@@ -45,6 +45,7 @@ def test_fix_incorrect_calldata(accounts, registry, pool_compound, lp_compound, 
         right_pad("0xdEAdbEEf"),
         pack_values([8, 8]),
         pack_values([18, 6]),
+        True,
         {'from': accounts[0]}
     )
 
@@ -60,6 +61,7 @@ def test_fix_incorrect_calldata(accounts, registry, pool_compound, lp_compound, 
         right_pad(cDAI.exchangeRateStored.signature),
         pack_values([8, 8]),
         pack_values([18, 6]),
+        True,
         {'from': accounts[0]}
     )
 
@@ -75,6 +77,7 @@ def test_without_underlying(accounts, registry, pool_compound, cDAI, cUSDC):
         right_pad(cDAI.exchangeRateStored.signature),
         pack_values([8, 8]),
         pack_values([True] + [False] * 7),
+        True,
         {'from': accounts[0]}
     )
 

--- a/tests/unitary/test_remove_pool.py
+++ b/tests/unitary/test_remove_pool.py
@@ -87,6 +87,7 @@ def test_get_pool_info(accounts, registry_all, pool_y, pool_susd, lp_susd):
         "0x00",
         pack_values([18, 6, 6, 18]),
         pack_values([18, 6, 6, 18]),
+        True,
         {'from': accounts[0]}
     )
     assert registry_all.get_pool_info(pool_susd) == pool_info


### PR DESCRIPTION
Add the following fields to `get_pool_info`:

* `future_A`
* `future_fee`
* `future_admin_fee`
* `future_owner`

For pools where the data is publicly exposed, the following fields are also available (if not available they are always returned as `0`):

* `initial_A`
* `initial_A_time`
* `future_A_time`