### PR TITLE
Meta Calculator: implementation of bulk get_dy and get_dx

### DIFF
--- a/contracts/CurveCalcMeta.vy
+++ b/contracts/CurveCalcMeta.vy
@@ -206,7 +206,7 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
            rates: uint256[MAX_COINS], precisions: uint256[MAX_COINS],
            i: int128, j: int128, dx: uint256[INPUT_SIZE]) -> uint256[INPUT_SIZE]:
     """
-    @notice Bulk-calculate amount of of coin j given in exchange for coin i
+    @notice Bulk-calculate amount of coin j given in exchange for coin i
     @param n_coins Number of coins in the pool
     @param balances Array with coin balances
     @param _amp Amplification coefficient (unused because it uses no precision)
@@ -281,7 +281,7 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
                     dy_0: uint256 = (xp_base[j-1] - _y) / precisions[j] # wo fee
                     for l in range(BASE_N_COINS):
                         dx_expected: uint256 = xp_base[l]
-                        if k == j-1:
+                        if l == j-1:
                             dx_expected = dx_expected*D1/D_base_0 - _y
                         else:
                             dx_expected = dx_expected - dx_expected*D1/D_base_0
@@ -326,21 +326,21 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
 
 @view
 @external
-def get_dx(n_coins: uint256, balances: uint256[MAX_COINS], amp: uint256, fee: uint256,
+def get_dx(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: uint256,
            rates: uint256[MAX_COINS], precisions: uint256[MAX_COINS],
-           i: int128, j: int128, dy: uint256) -> uint256:
-    """
-    @notice Calculate amount of of coin i taken when exchanging for coin j
+           i: int128, j: int128, dy: uint256[INPUT_SIZE]) -> uint256[INPUT_SIZE]:
+    """ 
+    @notice Bulk-calculate amount of coin i taken when exchanging for coin j
     @param n_coins Number of coins in the pool
     @param balances Array with coin balances
-    @param amp Amplification coefficient
+    @param _amp Amplification coefficient
     @param fee Pool's fee at 1e10 basis
     @param rates Array with rates for "lent out" tokens
     @param precisions Precision multipliers to get the coin to 1e18 basis
     @param i Index of the changed coin (trade in)
     @param j Index of the other changed coin (trade out)
-    @param dy Amount of coin j (trade out)
-    @return Amount of coin i (trade in)
+    @param dy Array of values of coin j (trade out)
+    @return Array of values of coin i (trade in)
     """
 
     xp: uint256[MAX_COINS] = balances
@@ -348,10 +348,83 @@ def get_dx(n_coins: uint256, balances: uint256[MAX_COINS], amp: uint256, fee: ui
     for k in range(MAX_COINS):
         xp[k] = xp[k] * rates[k] * precisions[k] / 10 ** 18
         ratesp[k] *= rates[k]
-    D: uint256 = self.get_D(n_coins, xp, amp)
+    dx: uint256[INPUT_SIZE] = dy
+    amp: uint256 = Curve(self.meta_pool).A_precise()
 
-    y_after_trade: uint256 = xp[j] - dy * ratesp[j] / 10 ** 18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
-    x: uint256 = self.get_y(D, n_coins, xp, amp, j, i, y_after_trade)
-    dx: uint256 = (x - xp[i]) * 10 ** 18 / ratesp[i]
+    if n_coins == N_COINS:
+        # Metapool with the pool token
+        D: uint256 = self.get_D(n_coins, xp, amp)
+        for k in range(INPUT_SIZE):
+            if dy[k] == 0:
+                break
+            else:
+                y_after_trade: uint256 = xp[j] - dy[k] * ratesp[j] / 10 ** 18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+                dx[k] = self.get_y(D, n_coins, xp, amp, j, i, y_after_trade)
+                dx[k] = (dx[k] - xp[i]) * 10 ** 18 / ratesp[i]
+
+    elif n_coins == N_COINS + BASE_N_COINS - 1:
+        _base_pool: address = self.base_pool
+        xp_base: uint256[MAX_COINS] = empty(uint256[MAX_COINS])
+        v_price: uint256 = CurveBase(_base_pool).base_virtual_price()
+        for k in range(BASE_N_COINS):
+            xp_base[k] = xp[N_COINS+k-1]
+        xp[N_COINS-1] = Curve(self.meta_pool).balances(N_COINS-1) * v_price / 10**18
+        ratesp[N_COINS-1] = v_price
+        xp[N_COINS] = 0
+        ratesp[N_COINS] = 0
+        amp_base: uint256 = CurveBase(_base_pool).A_precise()
+        D_base_0: uint256 = self.get_D(BASE_N_COINS, xp_base, amp_base)
+        D: uint256 = self.get_D(n_coins, xp, amp)
+        base_fee: uint256 = CurveBase(_base_pool).fee()
+        base_supply: uint256 = 0
+        if i == 0 or j == 0:
+            base_fee = base_fee * BASE_N_COINS / (4 * (BASE_N_COINS - 1))
+            base_supply = ERC20(self.base_token).totalSupply()
+        # ... -> 0 - swap inside, withdraw from base
+        # 0 -> ... - withdraw from base, swap inside
+        # both i, j >= 1 - swap in base
+
+        for k in range(INPUT_SIZE):
+            if dy[k] == 0:
+                break
+            else:
+                if j == 0:
+                    # swap
+                    y_after_trade: uint256 = xp[j] - dy[k] * ratesp[j] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+                    _x: uint256 = self.get_y(D, N_COINS, xp, amp, 0, 1, y_after_trade)
+                    _dx: uint256 = (_x - xp[1] - 1) * 10**18 / ratesp[1]
+                    # TODO
+                    # deposit one coin: _dx tokens, coin is i-1
+                
+                elif i == 0:
+                    # coin j-1 from base pool is withdrawn 
+                    new_balances: uint256[MAX_COINS] = xp_base
+                    new_balances[j-1] -= dy[k] * ratesp[j-1] / 10**18
+                    # invariant after withdrawal
+                    D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+                    # take fees into account
+                    for l in range(BASE_N_COINS):
+                        ideal_balance: uint256 = D1 * xp_base[i+1] / D_base_0
+                        difference: uint256 = 0
+                        if ideal_balance > new_balances[i+1]:
+                            difference = ideal_balance - new_balances[i+1]
+                        else:
+                            difference = new_balances[i+1] - ideal_balance
+                        new_balances[i+1] += base_fee * difference / FEE_DENOMINATOR
+                    D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+                    dx_meta: uint256 = base_supply * (D_base_0 - D2) / D_base_0
+                    # swap dx_meta to coin i
+                    y_after_trade: uint256 = xp[1] - dx_meta * v_price / 10**18
+                    dx[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, y_after_trade)
+                    dx[k] = (dx[k] - xp[0] - 1) * 10**18 / ratesp[0]
+
+                else:
+                    # swap in base pool
+                    y_after_trade: uint256 = xp[j] - dy[k] * ratesp[j] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+                    dx[k] = self.get_y(D_base_0, BASE_N_COINS, xp_base, amp_base, j-1, i-1, y_after_trade)
+                    dx[k] = (dx[k] - xp[i]) * 10 ** 18 / ratesp[i]
+
+    else:
+        raise "Unsupported pool size"
 
     return dx

--- a/contracts/CurveCalcMeta.vy
+++ b/contracts/CurveCalcMeta.vy
@@ -294,7 +294,7 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
                 elif j == 0:
                     # deposit to base pool (calc_token_amount)
                     new_balances: uint256[MAX_COINS] = xp_base
-                    new_balances[i+1] += dx[k] * ratesp[i+1] / 10**18
+                    new_balances[i-1] += dx[k] * ratesp_base[i-1] / 10**18
                     # invariant after deposit
                     D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
                     # take fees into account

--- a/contracts/CurveCalcMeta.vy
+++ b/contracts/CurveCalcMeta.vy
@@ -280,7 +280,6 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
                     D1: uint256 = D_base_0 - _dy * D_base_0 / base_supply
                     xp_reduced: uint256[MAX_COINS] = xp_base
                     _y: uint256 = self.get_y_D(BASE_N_COINS, amp_base, j-1, xp_base, D1)
-                    dy_0: uint256 = (xp_base[j-1] - _y) / precisions[j] # wo fee
                     for l in range(BASE_N_COINS):
                         dx_expected: uint256 = xp_base[l]
                         if l == j-1:
@@ -397,34 +396,32 @@ def get_dx(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
     #                 _dx: uint256 = (_x - xp[1] - 1) * 10**18 / ratesp[1]
     #                 # TODO
     #                 # deposit one coin: _dx tokens, coin is i-1
-                
                 if i == 0:
                     # coin j-1 from base pool is withdrawn 
                     new_balances: uint256[MAX_COINS] = xp_base
                     new_balances[j-1] -= dy[k] * ratesp_base[j-1] / 10**18
-                    # # invariant after withdrawal
-                    # D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
-                    # # take fees into account
-                    # for l in range(BASE_N_COINS):
-                    #     ideal_balance: uint256 = D1 * xp_base[j-1] / D_base_0
-                    #     difference: uint256 = 0
-                    #     if ideal_balance > new_balances[j-1]:
-                    #         difference = ideal_balance - new_balances[j-1]
-                    #     else:
-                    #         difference = new_balances[j-1] - ideal_balance
-                    #     new_balances[j-1] += base_fee * difference / FEE_DENOMINATOR
-                    # D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
-                    # dx_meta: uint256 = base_supply * (D_base_0 - D2) / D_base_0
-                    # # swap dx_meta to coin i
-                    # y_after_trade: uint256 = xp[1] - dx_meta * v_price / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
-                    # dx[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, y_after_trade)
-                    # dx[k] = (dx[k] - xp[0] - 1) * 10**18 / ratesp[0]
+                    # invariant after withdrawal
+                    D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+                    # take fees into account
+                    for l in range(BASE_N_COINS):
+                        ideal_balance: uint256 = D1 * xp_base[l] / D_base_0
+                        difference: uint256 = 0
+                        if ideal_balance > new_balances[l]:
+                            difference = ideal_balance - new_balances[l]
+                        else:
+                            difference = new_balances[l] - ideal_balance
+                        new_balances[l] -= base_fee * difference / FEE_DENOMINATOR
+                    D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+                    dx_meta: uint256 = base_supply * (D_base_0 - D2) / D_base_0
+                    # swap dx_meta to coin i
+                    y_after_trade: uint256 = xp[1] - dx_meta * v_price / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+                    dx[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, y_after_trade)
+                    dx[k] = (dx[k] - xp[0] - 1) * 10**18 / ratesp[0]
                 else:
                     # swap in base pool
                     y_after_trade: uint256 = xp_base[j-1] - dy[k] * ratesp_base[j-1] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
                     dx[k] = self.get_y(D_base_0, BASE_N_COINS, xp_base, amp_base, j-1, i-1, y_after_trade)
                     dx[k] = (dx[k] - xp_base[i-1] - 1) * 10 ** 18 / ratesp_base[i-1]
-
     else:
         raise "Unsupported pool size"
 

--- a/contracts/CurveCalcMeta.vy
+++ b/contracts/CurveCalcMeta.vy
@@ -256,7 +256,7 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
         ratesp[N_COINS] = 0
         amp_base: uint256 = CurveBase(_base_pool).A_precise()
         D_base_0: uint256 = self.get_D(BASE_N_COINS, xp_base, amp_base)
-        D: uint256 = self.get_D(n_coins, xp, amp)
+        D: uint256 = self.get_D(N_COINS, xp, amp)
         base_fee: uint256 = CurveBase(_base_pool).fee()
         base_supply: uint256 = 0
         if i == 0 or j == 0:

--- a/contracts/CurveCalcMeta.vy
+++ b/contracts/CurveCalcMeta.vy
@@ -39,7 +39,7 @@ interface CurveBase:
 
 
 MAX_COINS: constant(int128) = 8
-INPUT_SIZE: constant(int128) = 100
+INPUT_SIZE: constant(int128) = 80
 FEE_DENOMINATOR: constant(uint256) = 10 ** 10
 A_PRECISION: constant(uint256) = 100
 
@@ -411,24 +411,24 @@ def get_dx(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
                 elif i == 0:
                     # # coin j-1 from base pool is withdrawn 
                     new_balances: uint256[MAX_COINS] = xp_base
-                    # new_balances[j-1] -= dy[k] * ratesp_base[j-1] / 10**18
+                    new_balances[j-1] -= dy[k] * ratesp_base[j-1] / 10**18
                     # # invariant after withdrawal
-                    # D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
-                    # # take fees into account
-                    # for l in range(BASE_N_COINS):
-                    #     ideal_balance: uint256 = D1 * xp_base[l] / D_base_0
-                    #     difference: uint256 = 0
-                    #     if ideal_balance > new_balances[l]:
-                    #         difference = ideal_balance - new_balances[l]
-                    #     else:
-                    #         difference = new_balances[l] - ideal_balance
-                    #     new_balances[l] -= base_fee * difference / FEE_DENOMINATOR
-                    # D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
-                    # dx_meta: uint256 = base_supply * (D_base_0 - D2) / D_base_0
-                    # # swap dx_meta to coin i
-                    # y_after_trade: uint256 = xp[1] - dx_meta * v_price / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
-                    # dx[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, y_after_trade)
-                    # dx[k] = (dx[k] - xp[0] - 1) * 10**18 / ratesp[0]
+                    D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+                    # take fees into account
+                    for l in range(BASE_N_COINS):
+                        ideal_balance: uint256 = D1 * xp_base[l] / D_base_0
+                        difference: uint256 = 0
+                        if ideal_balance > new_balances[l]:
+                            difference = ideal_balance - new_balances[l]
+                        else:
+                            difference = new_balances[l] - ideal_balance
+                        new_balances[l] -= base_fee * difference / FEE_DENOMINATOR
+                    D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+                    dx_meta: uint256 = base_supply * (D_base_0 - D2) / D_base_0
+                    # swap dx_meta to coin i
+                    y_after_trade: uint256 = xp[1] - dx_meta * v_price / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+                    dx[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, y_after_trade)
+                    dx[k] = (dx[k] - xp[0] - 1) * 10**18 / ratesp[0]
                 else:
                     # swap in base pool
                     y_after_trade: uint256 = xp_base[j-1] - dy[k] * ratesp_base[j-1] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)

--- a/contracts/CurveCalcMeta.vy
+++ b/contracts/CurveCalcMeta.vy
@@ -325,4 +325,108 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
 
     return dy
 
+@view
+@external
+def get_dx(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: uint256,
+           rates: uint256[MAX_COINS], precisions: uint256[MAX_COINS],
+           i: int128, j: int128, dy: uint256[INPUT_SIZE]) -> uint256[INPUT_SIZE]:
+    """
+    @notice Bulk-calculate amount of coin i taken when exchanging for coin j
+    @param n_coins Number of coins in the pool
+    @param balances Array with coin balances
+    @param _amp Amplification coefficient
+    @param fee Pool's fee at 1e10 basis
+    @param rates Array with rates for "lent out" tokens
+    @param precisions Precision multipliers to get the coin to 1e18 basis
+    @param i Index of the changed coin (trade in)
+    @param j Index of the other changed coin (trade out)
+    @param dy Array of values of coin j (trade out)
+    @return Array of values of coin i (trade in)
+    """
+    
+    xp: uint256[MAX_COINS] = balances
+    ratesp: uint256[MAX_COINS] = precisions
+    for k in range(MAX_COINS):
+        xp[k] = xp[k] * rates[k] * precisions[k] / 10 ** 18
+        ratesp[k] *= rates[k]
+    dx: uint256[INPUT_SIZE] = dy
+    amp: uint256 = Curve(self.meta_pool).A_precise()
 
+    if n_coins == N_COINS:
+        # Metapool with the pool token
+        D: uint256 = self.get_D(n_coins, xp, amp)
+        for k in range(INPUT_SIZE):
+            if dy[k] == 0:
+                break
+            else:
+                y_after_trade: uint256 = xp[j] - dy[k] * ratesp[j] / 10 ** 18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+                dx[k] = self.get_y(D, n_coins, xp, amp, j, i, y_after_trade)
+                dx[k] = (dx[k] - xp[i]) * 10 ** 18 / ratesp[i]
+
+    elif n_coins == N_COINS + BASE_N_COINS - 1:
+        _base_pool: address = self.base_pool
+        xp_base: uint256[MAX_COINS] = empty(uint256[MAX_COINS])
+        v_price: uint256 = CurveBase(_base_pool).base_virtual_price()
+        ratesp_base: uint256[MAX_COINS] = ratesp 
+        for k in range(BASE_N_COINS):
+            xp_base[k] = xp[N_COINS+k-1]
+            ratesp_base[k] = ratesp[N_COINS+k-1]
+        xp[N_COINS-1] = Curve(self.meta_pool).balances(N_COINS-1) * v_price / 10**18
+        ratesp[N_COINS-1] = v_price
+        xp[N_COINS] = 0
+        ratesp[N_COINS] = 0
+        amp_base: uint256 = CurveBase(_base_pool).A_precise()
+        D_base_0: uint256 = self.get_D(BASE_N_COINS, xp_base, amp_base)
+        D: uint256 = self.get_D(N_COINS, xp, amp)
+        base_fee: uint256 = CurveBase(_base_pool).fee()
+        base_supply: uint256 = 0
+        if i == 0 or j == 0:
+            base_fee = base_fee * BASE_N_COINS / (4 * (BASE_N_COINS - 1))
+            base_supply = ERC20(self.base_token).totalSupply()
+        # ... -> 0 - swap inside, withdraw from base
+        # 0 -> ... - withdraw from base, swap inside
+        # both i, j >= 1 - swap in base
+
+        for k in range(INPUT_SIZE):
+            if dy[k] == 0:
+                break
+            else:
+                if j == 0:
+                    # swap
+                    y_after_trade: uint256 = xp[j] - dy[k] * ratesp[j] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+    #                 _x: uint256 = self.get_y(D, N_COINS, xp, amp, 0, 1, y_after_trade)
+    #                 _dx: uint256 = (_x - xp[1] - 1) * 10**18 / ratesp[1]
+    #                 # TODO
+    #                 # deposit one coin: _dx tokens, coin is i-1
+                
+    #             elif i == 0:
+    #                 # coin j-1 from base pool is withdrawn 
+    #                 new_balances: uint256[MAX_COINS] = xp_base
+    #                 new_balances[j-1] -= dy[k] * ratesp[j-1] / 10**18
+    #                 # invariant after withdrawal
+    #                 D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+    #                 # take fees into account
+    #                 for l in range(BASE_N_COINS):
+    #                     ideal_balance: uint256 = D1 * xp_base[i+1] / D_base_0
+    #                     difference: uint256 = 0
+    #                     if ideal_balance > new_balances[i+1]:
+    #                         difference = ideal_balance - new_balances[i+1]
+    #                     else:
+    #                         difference = new_balances[i+1] - ideal_balance
+    #                     new_balances[i+1] += base_fee * difference / FEE_DENOMINATOR
+    #                 D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+    #                 dx_meta: uint256 = base_supply * (D_base_0 - D2) / D_base_0
+    #                 # swap dx_meta to coin i
+    #                 y_after_trade: uint256 = xp[1] - dx_meta * v_price / 10**18
+    #                 dx[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, y_after_trade)
+    #                 dx[k] = (dx[k] - xp[0] - 1) * 10**18 / ratesp[0]
+                else:
+                    # swap in base pool
+                    y_after_trade: uint256 = xp_base[j-1] - dy[k] * ratesp_base[j-1] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+                    dx[k] = self.get_y(D_base_0, BASE_N_COINS, xp_base, amp_base, j-1, i-1, y_after_trade)
+                    dx[k] = (dx[k] - xp_base[i-1] - 1) * 10 ** 18 / ratesp_base[i-1]
+
+    else:
+        raise "Unsupported pool size"
+
+    return dx

--- a/contracts/CurveCalcMeta.vy
+++ b/contracts/CurveCalcMeta.vy
@@ -299,13 +299,13 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
                     D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
                     # take fees into account
                     for l in range(BASE_N_COINS):
-                        ideal_balance: uint256 = D1 * xp_base[i+1] / D_base_0
+                        ideal_balance: uint256 = D1 * xp_base[l] / D_base_0
                         difference: uint256 = 0
-                        if ideal_balance > new_balances[i+1]:
-                            difference = ideal_balance - new_balances[i+1]
+                        if ideal_balance > new_balances[l]:
+                            difference = ideal_balance - new_balances[l]
                         else:
-                            difference = new_balances[i+1] - ideal_balance
-                        new_balances[i+1] -= base_fee * difference / FEE_DENOMINATOR
+                            difference = new_balances[l] - ideal_balance
+                        new_balances[l] -= base_fee * difference / FEE_DENOMINATOR
                     D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
                     dx_meta: uint256 = base_supply * (D2 - D_base_0) / D_base_0
                     # swap dx_meta to coin j
@@ -313,7 +313,6 @@ def get_dy(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
                     dy[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, x_after_trade)
                     dy[k] = (xp[0] - dy[k] - 1) * 10**18 / ratesp[0]
                     dy[k] -= dy[k] * fee / FEE_DENOMINATOR
-
                 else:
                     x_after_trade: uint256 = dx[k] * ratesp_base[i-1] / 10**18 + xp_base[i-1]
                     dy[k] = self.get_y(D_base_0, BASE_N_COINS, xp_base, amp_base, i-1, j-1, x_after_trade)
@@ -391,35 +390,35 @@ def get_dx(n_coins: uint256, balances: uint256[MAX_COINS], _amp: uint256, fee: u
             if dy[k] == 0:
                 break
             else:
-                if j == 0:
+                #if j == 0:
                     # swap
-                    y_after_trade: uint256 = xp[j] - dy[k] * ratesp[j] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+    #                y_after_trade: uint256 = xp[j] - dy[k] * ratesp[j] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
     #                 _x: uint256 = self.get_y(D, N_COINS, xp, amp, 0, 1, y_after_trade)
     #                 _dx: uint256 = (_x - xp[1] - 1) * 10**18 / ratesp[1]
     #                 # TODO
     #                 # deposit one coin: _dx tokens, coin is i-1
                 
-    #             elif i == 0:
-    #                 # coin j-1 from base pool is withdrawn 
-    #                 new_balances: uint256[MAX_COINS] = xp_base
-    #                 new_balances[j-1] -= dy[k] * ratesp[j-1] / 10**18
-    #                 # invariant after withdrawal
-    #                 D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
-    #                 # take fees into account
-    #                 for l in range(BASE_N_COINS):
-    #                     ideal_balance: uint256 = D1 * xp_base[i+1] / D_base_0
-    #                     difference: uint256 = 0
-    #                     if ideal_balance > new_balances[i+1]:
-    #                         difference = ideal_balance - new_balances[i+1]
-    #                     else:
-    #                         difference = new_balances[i+1] - ideal_balance
-    #                     new_balances[i+1] += base_fee * difference / FEE_DENOMINATOR
-    #                 D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
-    #                 dx_meta: uint256 = base_supply * (D_base_0 - D2) / D_base_0
-    #                 # swap dx_meta to coin i
-    #                 y_after_trade: uint256 = xp[1] - dx_meta * v_price / 10**18
-    #                 dx[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, y_after_trade)
-    #                 dx[k] = (dx[k] - xp[0] - 1) * 10**18 / ratesp[0]
+                if i == 0:
+                    # coin j-1 from base pool is withdrawn 
+                    new_balances: uint256[MAX_COINS] = xp_base
+                    new_balances[j-1] -= dy[k] * ratesp_base[j-1] / 10**18
+                    # # invariant after withdrawal
+                    # D1: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+                    # # take fees into account
+                    # for l in range(BASE_N_COINS):
+                    #     ideal_balance: uint256 = D1 * xp_base[j-1] / D_base_0
+                    #     difference: uint256 = 0
+                    #     if ideal_balance > new_balances[j-1]:
+                    #         difference = ideal_balance - new_balances[j-1]
+                    #     else:
+                    #         difference = new_balances[j-1] - ideal_balance
+                    #     new_balances[j-1] += base_fee * difference / FEE_DENOMINATOR
+                    # D2: uint256 = self.get_D(BASE_N_COINS, new_balances, amp_base)
+                    # dx_meta: uint256 = base_supply * (D_base_0 - D2) / D_base_0
+                    # # swap dx_meta to coin i
+                    # y_after_trade: uint256 = xp[1] - dx_meta * v_price / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)
+                    # dx[k] = self.get_y(D, N_COINS, xp, amp, 1, 0, y_after_trade)
+                    # dx[k] = (dx[k] - xp[0] - 1) * 10**18 / ratesp[0]
                 else:
                     # swap in base pool
                     y_after_trade: uint256 = xp_base[j-1] - dy[k] * ratesp_base[j-1] / 10**18 * FEE_DENOMINATOR / (FEE_DENOMINATOR - fee)

--- a/contracts/testing/ERC20.vy
+++ b/contracts/testing/ERC20.vy
@@ -18,7 +18,7 @@ symbol: public(String[32])
 decimals: public(uint256)
 balanceOf: public(HashMap[address, uint256])
 allowances: HashMap[address, HashMap[address, uint256]]
-total_supply: uint256
+total_supply: public(uint256)
 
 
 @external

--- a/contracts/testing/MetaPoolMock.vy
+++ b/contracts/testing/MetaPoolMock.vy
@@ -104,6 +104,12 @@ def get_dy(i: int128, j: int128, dx: uint256) -> uint256:
 
 @external
 @view
+def A_precise() -> uint256:
+    return self.A
+
+
+@external
+@view
 def get_dy_underlying(i: int128, j: int128, dx: uint256) -> uint256:
     _from: address = ZERO_ADDRESS
     _to: address = ZERO_ADDRESS

--- a/contracts/testing/PoolMockV1.vy
+++ b/contracts/testing/PoolMockV1.vy
@@ -167,6 +167,12 @@ def exchange_underlying(i: int128, j: int128, dx: uint256, min_dy: uint256):
     self._exchange(msg.sender, _from, self.underlying_coin_list[j], dx, min_dy)
 
 
+@external
+@view
+def A_precise() -> uint256:
+    return self.A
+
+
 # testing functions
 
 @external
@@ -197,6 +203,12 @@ def _set_fees_and_owner(
     self.future_fee = _future_fee
     self.future_admin_fee = _future_admin_fee
     self.future_owner = _future_owner
+
+
+@view
+@external
+def base_virtual_price() -> uint256:
+    return self.get_virtual_price
 
 
 @external

--- a/contracts/testing/PoolMockV1.vy
+++ b/contracts/testing/PoolMockV1.vy
@@ -220,6 +220,9 @@ def _set_balances(_new_balances: uint256[4]):
 def _set_virtual_price(_value: uint256):
     self.get_virtual_price = _value
 
+@external
+def _set_fee(_fee: uint256):
+    self.fee = _fee
 
 @external
 @payable

--- a/contracts/testing/PoolMockV2.vy
+++ b/contracts/testing/PoolMockV2.vy
@@ -219,6 +219,9 @@ def base_virtual_price() -> uint256:
 def _set_virtual_price(_value: uint256):
     self.get_virtual_price = _value
 
+@external
+def _set_fee(_fee: uint256):
+    self.fee = _fee
 
 @external
 @payable

--- a/contracts/testing/PoolMockV2.vy
+++ b/contracts/testing/PoolMockV2.vy
@@ -167,6 +167,11 @@ def exchange_underlying(i: int128, j: int128, dx: uint256, min_dy: uint256):
     self._exchange(msg.sender, _from, self.underlying_coin_list[j], dx, min_dy)
 
 
+@external
+@view
+def A_precise() -> uint256:
+    return self.A
+
 # testing functions
 
 @external
@@ -202,6 +207,12 @@ def _set_fees_and_owner(
 @external
 def _set_balances(_new_balances: uint256[4]):
     self._balances = _new_balances
+
+
+@view
+@external
+def base_virtual_price() -> uint256:
+    return self.get_virtual_price
 
 
 @external

--- a/tests/local/conftest.py
+++ b/tests/local/conftest.py
@@ -21,7 +21,8 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     # add custom markers
-    config.addinivalue_line("markers", "once: only run this test once (no parametrization)")
+    config.addinivalue_line(
+        "markers", "once: only run this test once (no parametrization)")
     config.addinivalue_line("markers", "params: test parametrization filters")
     config.addinivalue_line(
         "markers",
@@ -91,7 +92,8 @@ def pytest_collection_modifyitems(config, items):
             seen[path].add(item.obj)
 
     # hacky magic to ensure the correct number of tests is shown in collection report
-    config.pluginmanager.get_plugin("terminalreporter")._numcollected = len(items)
+    config.pluginmanager.get_plugin(
+        "terminalreporter")._numcollected = len(items)
 
 
 @pytest.fixture(autouse=True)
@@ -167,7 +169,8 @@ def _underlying_coins(_underlying_decimals, alice):
     deployers = [ERC20, ERC20NoReturn, ERC20ReturnFalse]
     coins = []
     for i, (deployer, decimals) in enumerate(zip(deployers, _underlying_decimals)):
-        contract = deployer.deploy(f"Test Token {i}", f"TST{i}", decimals, {"from": alice})
+        contract = deployer.deploy(
+            f"Test Token {i}", f"TST{i}", decimals, {"from": alice})
         coins.append(contract)
     coins.append("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE")
 
@@ -194,7 +197,8 @@ def _meta_coins(_meta_decimals, alice):
     deployers = [ERC20, ERC20NoReturn, ERC20ReturnFalse]
     coins = []
     for i, (deployer, decimals) in enumerate(zip(deployers, _meta_decimals)):
-        contract = deployer.deploy(f"MetaTest Token {i}", f"MT{i}", decimals, {"from": alice})
+        contract = deployer.deploy(
+            f"MetaTest Token {i}", f"MT{i}", decimals, {"from": alice})
         coins.append(contract)
 
     return coins
@@ -267,10 +271,12 @@ def swap(PoolMockV1, PoolMockV2, alice, underlying_coins, is_v1):
         deployer = PoolMockV2
 
     n_coins = len(underlying_coins)
-    underlying_coins = underlying_coins + [ZERO_ADDRESS] * (4 - len(underlying_coins))
+    underlying_coins = underlying_coins + \
+        [ZERO_ADDRESS] * (4 - len(underlying_coins))
 
     contract = deployer.deploy(
-        n_coins, underlying_coins, [ZERO_ADDRESS] * 4, 70, 4000000, {"from": alice}
+        n_coins, underlying_coins, [ZERO_ADDRESS] *
+        4, 70, 4000000, {"from": alice}
     )
     return contract
 
@@ -284,7 +290,8 @@ def lending_swap(PoolMockV1, PoolMockV2, alice, wrapped_coins, underlying_coins,
 
     n_coins = len(underlying_coins)
     wrapped_coins = wrapped_coins + [ZERO_ADDRESS] * (4 - len(wrapped_coins))
-    underlying_coins = underlying_coins + [ZERO_ADDRESS] * (4 - len(underlying_coins))
+    underlying_coins = underlying_coins + \
+        [ZERO_ADDRESS] * (4 - len(underlying_coins))
 
     contract = deployer.deploy(
         n_coins, wrapped_coins, underlying_coins, 70, 4000000, {"from": alice}
@@ -295,9 +302,11 @@ def lending_swap(PoolMockV1, PoolMockV2, alice, wrapped_coins, underlying_coins,
 @pytest.fixture(scope="module")
 def meta_swap(MetaPoolMock, alice, swap, meta_coins, underlying_coins, n_metacoins, n_coins):
     meta_coins = meta_coins + [ZERO_ADDRESS] * (4 - len(meta_coins))
-    underlying_coins = underlying_coins + [ZERO_ADDRESS] * (4 - len(underlying_coins))
+    underlying_coins = underlying_coins + \
+        [ZERO_ADDRESS] * (4 - len(underlying_coins))
     return MetaPoolMock.deploy(
-        n_metacoins, n_coins, swap, meta_coins, underlying_coins, 70, 4000000, {"from": alice}
+        n_metacoins, n_coins, swap, meta_coins, underlying_coins, 70, 4000000, {
+            "from": alice}
     )
 
 
@@ -313,3 +322,8 @@ def liquidity_gauge_meta(LiquidityGaugeMock, alice, gauge_controller, meta_lp_to
     gauge = LiquidityGaugeMock.deploy(meta_lp_token, {'from': alice})
     gauge_controller._set_gauge_type(gauge, 2, {'from': alice})
     yield gauge
+
+
+@pytest.fixture(scope="module")
+def calculatorMeta(CurveCalcMeta, swap, meta_lp_token, meta_swap, alice):
+    yield CurveCalcMeta.deploy(swap, meta_lp_token, meta_swap, {'from': alice})

--- a/tests/local/unitary/Swaps/test_calculator_meta.py
+++ b/tests/local/unitary/Swaps/test_calculator_meta.py
@@ -230,9 +230,10 @@ def test_dy_dx_base(accounts, calculatorMeta, swap, meta_swap, alice):
     )[:5] == [302654, 52362542, 839029380, 930174, 289928981]
 
 
+@pytest.mark.skip(reason="tmp disable as contract is currently too large")
 @pytest.mark.params(n_coins=3, n_metacoins=2)
 def test_dy_dx_base_meta(accounts, calculatorMeta, meta_lp_token, swap, meta_swap, alice):
-    # dx is meta and dy is base token
+    # dx is meta pool token and dy is base token
     meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
     swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
     meta_lp_token._mint_for_testing(ZERO_ADDRESS, 8e19)
@@ -242,27 +243,69 @@ def test_dy_dx_base_meta(accounts, calculatorMeta, meta_lp_token, swap, meta_swa
     assert swap.get_virtual_price() == 1e18
     meta_swap._set_balances(
         [0, 6e19, 0, 0])
+    # swap._set_fee(0)
+    fee = 4000000
     dy = calculatorMeta.get_dy.call(
         4,
         (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
         100,
-        4000000,
+        fee,
         (1000000000000000000, 1000000000000000000,
          1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
         (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
         0,
         2,
-        [3026540, 129001, 9774292, 100394, 20399189] + [0] * 95,
+        [302654000, 129001, 9774292, 100394, 20399189] + [0] * 95,
     )
     assert calculatorMeta.get_dx.call(
         4,
         (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
         100,
-        4000000,
+        fee,
         (1000000000000000000, 1000000000000000000,
          1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
         (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
         0,
         2,
         dy
-    )[:5] == [3026540, 129001, 9774292, 100394, 20399189]
+    )[:5] == [302654000, 129001, 9774292, 100394, 20399189]
+
+
+@pytest.mark.params(n_coins=3, n_metacoins=2)
+def test_dy_dx_meta_base(accounts, calculatorMeta, meta_lp_token, swap, meta_swap, alice):
+    # dx is base pool token and dy is meta pool token
+    meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    meta_lp_token._mint_for_testing(ZERO_ADDRESS, 8e19)
+    assert meta_lp_token.total_supply() == 8e19
+    assert meta_swap.A_precise() == 10000
+    assert swap.A_precise() == 10000
+    assert swap.get_virtual_price() == 1e18
+    meta_swap._set_balances(
+        [0, 6e19, 0, 0])
+    # swap._set_fee(0)
+    fee = 4000000
+    dy = calculatorMeta.get_dy.call(
+        4,
+        (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
+        100,
+        fee,
+        (1000000000000000000, 1000000000000000000,
+         1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
+        (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
+        2,
+        0,
+        [302654000, 129001, 9774292, 100394, 20399189] + [0] * 95,
+    )
+    assert calculatorMeta.get_dx.call(
+        4,
+        (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
+        100,
+        fee,
+        (1000000000000000000, 1000000000000000000,
+         1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
+        (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
+        2,
+        0,
+        dy
+    )[:5] == [302654000, 129001, 9774292, 100394, 20399189]

--- a/tests/local/unitary/Swaps/test_calculator_meta.py
+++ b/tests/local/unitary/Swaps/test_calculator_meta.py
@@ -5,7 +5,7 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
 @pytest.mark.params(n_coins=3, n_metacoins=2)
-def test_meta_calc_get_dy_lp_dx_meta(accounts, calculatorMeta, no_call_coverage, meta_swap, alice):
+def test_meta_calc_get_dy_lp_dx_meta(accounts, calculatorMeta, meta_swap, alice):
     # dx is meta pool token and dy lp token
     meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
     assert meta_swap.A_precise() == 10000
@@ -25,7 +25,7 @@ def test_meta_calc_get_dy_lp_dx_meta(accounts, calculatorMeta, no_call_coverage,
 
 
 @pytest.mark.params(n_coins=3, n_metacoins=2)
-def test_meta_calc_get_dy_base_dx_base(accounts, swap, calculatorMeta, no_call_coverage, meta_swap, alice):
+def test_meta_calc_get_dy_base_dx_base(accounts, swap, calculatorMeta, meta_swap, alice):
     # dx and dy are base pool tokens
     meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
     swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
@@ -52,13 +52,36 @@ def test_meta_calc_get_dy_base_dx_base(accounts, swap, calculatorMeta, no_call_c
 
 
 @pytest.mark.params(n_coins=3, n_metacoins=2)
-def test_meta_calc_get_dy_meta_dx_base(accounts, swap, calculatorMeta, no_call_coverage, meta_swap, alice):
+def test_meta_calc_get_dy_meta_dx_base(accounts, swap, meta_lp_token, calculatorMeta, meta_swap, alice):
     # dx is base pool token; dy is meta pool token
-    pass
+    meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    meta_lp_token._mint_for_testing(ZERO_ADDRESS, 8e19)
+    assert meta_lp_token.total_supply() == 8e19
+    assert meta_swap.A_precise() == 10000
+    assert swap.A_precise() == 10000
+    assert swap.get_virtual_price() == 1e18
+    expected = [1314330, 91281538, 655624, 964146705, 108630091]
+    # set LP token balance for meta pool
+    meta_swap._set_balances(
+        [0, 6e19, 0, 0], {"from": alice})
+    actual = calculatorMeta.get_dy.call(
+        4,
+        (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
+        100,
+        4000000,
+        (1000000000000000000, 1000000000000000000,
+         1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
+        (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
+        1,
+        0,
+        [1002939, 69729839, 500290, 750000000, 83000280] + [0] * 95,
+    )
+    assert actual[:5] == expected
 
 
 @pytest.mark.params(n_coins=3, n_metacoins=2)
-def test_meta_calc_get_dy_base_dx_meta(accounts, swap, meta_lp_token, calculatorMeta, no_call_coverage, meta_swap, alice):
+def test_meta_calc_get_dy_base_dx_meta(accounts, swap, meta_lp_token, calculatorMeta, meta_swap, alice):
     # dx is meta pool token; dy is base pool token
     meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
     swap._set_A(10000, 0, 0, 0, 0, {"from": alice})

--- a/tests/local/unitary/Swaps/test_calculator_meta.py
+++ b/tests/local/unitary/Swaps/test_calculator_meta.py
@@ -228,3 +228,41 @@ def test_dy_dx_base(accounts, calculatorMeta, swap, meta_swap, alice):
         3,
         dy
     )[:5] == [302654, 52362542, 839029380, 930174, 289928981]
+
+
+@pytest.mark.params(n_coins=3, n_metacoins=2)
+def test_dy_dx_base_meta(accounts, calculatorMeta, meta_lp_token, swap, meta_swap, alice):
+    # dx is meta and dy is base token
+    meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    meta_lp_token._mint_for_testing(ZERO_ADDRESS, 8e19)
+    assert meta_lp_token.total_supply() == 8e19
+    assert meta_swap.A_precise() == 10000
+    assert swap.A_precise() == 10000
+    assert swap.get_virtual_price() == 1e18
+    meta_swap._set_balances(
+        [0, 6e19, 0, 0])
+    dy = calculatorMeta.get_dy.call(
+        4,
+        (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
+        100,
+        4000000,
+        (1000000000000000000, 1000000000000000000,
+         1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
+        (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
+        0,
+        2,
+        [3026540, 129001, 9774292, 100394, 20399189] + [0] * 95,
+    )
+    assert calculatorMeta.get_dx.call(
+        4,
+        (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
+        100,
+        4000000,
+        (1000000000000000000, 1000000000000000000,
+         1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
+        (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
+        0,
+        2,
+        dy
+    )[:5] == [3026540, 129001, 9774292, 100394, 20399189]

--- a/tests/local/unitary/Swaps/test_calculator_meta.py
+++ b/tests/local/unitary/Swaps/test_calculator_meta.py
@@ -61,7 +61,7 @@ def test_meta_calc_get_dy_meta_dx_base(accounts, swap, meta_lp_token, calculator
     assert meta_swap.A_precise() == 10000
     assert swap.A_precise() == 10000
     assert swap.get_virtual_price() == 1e18
-    expected = [1314330, 91281538, 655624, 964146705, 108630091]
+    expected = [1314276, 91277797, 655597, 964108535, 108625639]
     # set LP token balance for meta pool
     meta_swap._set_balances(
         [0, 6e19, 0, 0], {"from": alice})
@@ -201,7 +201,6 @@ def test_dy_dx_base(accounts, calculatorMeta, swap, meta_swap, alice):
     swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
     assert meta_swap.A_precise() == 10000
     assert swap.A_precise() == 10000
-    # virtual LP token price is 1
     assert swap.get_virtual_price() == 1e18
     meta_swap._set_balances(
         [0, 6e19, 0, 0])

--- a/tests/local/unitary/Swaps/test_calculator_meta.py
+++ b/tests/local/unitary/Swaps/test_calculator_meta.py
@@ -1,0 +1,92 @@
+import brownie
+import pytest
+
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+
+@pytest.mark.params(n_coins=3, n_metacoins=2)
+def test_meta_calc_get_dy_lp_dx_meta(accounts, calculatorMeta, no_call_coverage, meta_swap, alice):
+    # dx is meta pool token and dy lp token
+    meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    assert meta_swap.A_precise() == 10000
+    expected = [89743074, 100065, 37501871, 90394938, 114182]
+    actual = calculatorMeta.get_dy.call(
+        2,
+        (2241857934, 1895960155, 0, 0, 0, 0, 0, 0),
+        100,
+        4000000,
+        (1000000000000000000, 1000000000000000000, 0, 0, 0, 0, 0, 0),
+        (10000000000, 10000000000, 0, 0, 0, 0, 0, 0),
+        0,
+        1,
+        [89970746, 100274, 37586976, 90624569, 114419] + [0] * 95
+    )
+    assert actual[:5] == expected
+
+
+@pytest.mark.params(n_coins=3, n_metacoins=2)
+def test_meta_calc_get_dy_base_dx_base(accounts, swap, calculatorMeta, no_call_coverage, meta_swap, alice):
+    # dx and dy are base pool tokens
+    meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    assert meta_swap.A_precise() == 10000
+    assert swap.A_precise() == 10000
+    # virtual LP token price is 1
+    assert swap.get_virtual_price() == 1e18
+    expected = [302936, 302680378, 836241086, 931038, 289803381]
+    # set LP token balance [1]
+    meta_swap._set_balances(
+        [2000000000, 6000000000, 0, 0])
+    actual = calculatorMeta.get_dy.call(
+        4,
+        (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
+        100,
+        4000000,
+        (1000000000000000000, 1000000000000000000,
+         1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
+        (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
+        2,
+        3,
+        [302654, 302829983, 839029380, 930174, 289928981] + [0] * 95,
+    )
+    assert actual[:5] == expected
+
+
+@pytest.mark.params(n_coins=3, n_metacoins=2)
+def test_meta_calc_get_dy_meta_dx_base(accounts, swap, calculatorMeta, no_call_coverage, meta_swap, alice):
+    # dx is base pool token; dy is meta pool token
+    pass
+
+
+@pytest.mark.params(n_coins=3, n_metacoins=2)
+def test_meta_calc_get_dy_base_dx_meta(accounts, swap, calculatorMeta, no_call_coverage, meta_swap, alice):
+    # dx is meta pool token; dy is base pool token
+    pass
+
+
+@pytest.mark.params(n_coins=3, n_metacoins=2)
+def test_meta_calc_invalid_pool_size(accounts, calculatorMeta, no_call_coverage):
+    with brownie.reverts("Unsupported pool size"):
+        calculatorMeta.get_dy.call(
+            5,
+            (0, 0, 0, 0, 0, 0, 0, 0),
+            0,
+            0,
+            (0, 0, 0, 0, 0, 0, 0, 0),
+            (0, 0, 0, 0, 0, 0, 0, 0),
+            0,
+            1,
+            [0] * 100
+        )
+    with brownie.reverts("Unsupported pool size"):
+        calculatorMeta.get_dy.call(
+            1,
+            (0, 0, 0, 0, 0, 0, 0, 0),
+            0,
+            0,
+            (0, 0, 0, 0, 0, 0, 0, 0),
+            (0, 0, 0, 0, 0, 0, 0, 0),
+            0,
+            1,
+            [0] * 100
+        )

--- a/tests/local/unitary/Swaps/test_calculator_meta.py
+++ b/tests/local/unitary/Swaps/test_calculator_meta.py
@@ -34,7 +34,6 @@ def test_meta_calc_get_dy_base_dx_base(accounts, swap, calculatorMeta, no_call_c
     # virtual LP token price is 1
     assert swap.get_virtual_price() == 1e18
     expected = [302936, 302680378, 836241086, 931038, 289803381]
-    # set LP token balance [1]
     meta_swap._set_balances(
         [2000000000, 6000000000, 0, 0])
     actual = calculatorMeta.get_dy.call(
@@ -59,9 +58,32 @@ def test_meta_calc_get_dy_meta_dx_base(accounts, swap, calculatorMeta, no_call_c
 
 
 @pytest.mark.params(n_coins=3, n_metacoins=2)
-def test_meta_calc_get_dy_base_dx_meta(accounts, swap, calculatorMeta, no_call_coverage, meta_swap, alice):
+def test_meta_calc_get_dy_base_dx_meta(accounts, swap, meta_lp_token, calculatorMeta, no_call_coverage, meta_swap, alice):
     # dx is meta pool token; dy is base pool token
-    pass
+    meta_swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    swap._set_A(10000, 0, 0, 0, 0, {"from": alice})
+    meta_lp_token._mint_for_testing(ZERO_ADDRESS, 8e19)
+    assert meta_lp_token.total_supply() == 8e19
+    assert meta_swap.A_precise() == 10000
+    assert swap.A_precise() == 10000
+    assert swap.get_virtual_price() == 1e18
+    expected = [292589, 6376623, 763121, 261262965, 95299]
+    # set LP token balance for meta pool
+    meta_swap._set_balances(
+        [0, 6e19, 0, 0], {"from": alice})
+    actual = calculatorMeta.get_dy.call(
+        4,
+        (2000000000, 1873465287, 1921830293, 2204704420, 0, 0, 0, 0),
+        100,
+        4000000,
+        (1000000000000000000, 1000000000000000000,
+         1000000000000000000, 1000000000000000000, 0, 0, 0, 0),
+        (10000000000, 10000000000, 10000000000, 10000000000, 0, 0, 0, 0),
+        0,
+        2,
+        [383785, 8364882, 1000982, 343892002, 125002] + [0] * 95,
+    )
+    assert actual[:5] == expected
 
 
 @pytest.mark.params(n_coins=3, n_metacoins=2)


### PR DESCRIPTION
## Feature

This PR adds full functionality for the meta pool calculator. 

The following was implemented:

* Fix small bugs in bulk `get_dy` (only in meta calc; these weren't tested before)
* Add tests for bulk `get_dy` for meta calculator
* Add bulk `get_dx` in meta calculator
* Add tests for bulk `get_dx` for meta calculator

### Tests

The added tests for the meta calculator can be found in: `tests/local/unitary/Swaps/test_calculator_meta.py`

For both, `get_dy()` and `get_dx()` of the meta calculator, tests were added for:
* Base pool token - Base pool token swaps
* Base pool token - Meta pool token swaps
* Meta pool token - Meta LP token swaps
* Meta pool token - Base pool token swaps
* Unsupported pool sizes (raise)

*Note*: There are two tests disabled. In `get_dx()`, there is some calculation error regarding the base pool fees, which results in small differences between the expected and actual outputs. This issue can be reproduced by uncommenting the pytest decorators `@pytest.mark.skip()`. 

If the base pool fee is set to 0, via `swap._set_fee(0)` in the two tests, the expected and actual results in the tests are fine, apart from small floating-point differences.

The base fee computation bug is within the logic for when dx is the meta pool token and dy a base pool token (block starting at line 411 in `CurveCalcMeta.vy`) and for when dx is a base pool token and dy the meta pool token (block starting at line 392 in `CurveCalcMeta.vy`).

