### PR TITLE
Feat/gauge registry

### DIFF
--- a/contracts/GaugeRegistry.vy
+++ b/contracts/GaugeRegistry.vy
@@ -1,0 +1,61 @@
+# @version 0.2.15
+"""
+@title Curve Gauge Registry
+@license MIT
+"""
+
+
+interface Factory:
+    def gauge_implementation() -> address: view
+
+
+PROXY_PRE_BYTECODE: constant(Bytes[15]) = 0x366000600037611000600036600073
+PROXY_POST_BYTECODE: constant(Bytes[16]) = 0x5AF4602C57600080FD5B6110006000F3
+
+
+owner: public(address)
+factory: public(address)
+chain_id: public(uint256)
+
+gauge_count: public(uint256)
+gauge_list: public(address[MAX_UINT256])
+# [pool_address 20 bytes][version 12 bytes]
+gauge_data: HashMap[address, uint256]
+
+
+@external
+def __init__(_factory: address):
+    self.owner = msg.sender
+    self.chain_id = chain.id
+
+
+@pure
+@internal
+def _get_proxy_codehash(_impl_addr: Bytes[20]) -> bytes32:
+    return keccak256(concat(PROXY_PRE_BYTECODE, _impl_addr, PROXY_POST_BYTECODE))
+
+
+@external
+def register(_gauge: address, _version: uint256, _pool: address = ZERO_ADDRESS):
+    impl_addr: Bytes[20] = slice(
+        convert(Factory(self.factory).gauge_implementation(), bytes32), 12, 20
+    )
+    assert msg.sender.codehash == self._get_proxy_codehash(impl_addr) or msg.sender == self.owner
+
+    index: uint256 = self.gauge_count
+    self.gauge_list[index] = _gauge
+    self.gauge_count = index + 1
+
+    self.gauge_data[_gauge] = shift(convert(_pool, uint256), 96) + _version
+
+
+@view
+@external
+def pool_address(_gauge: address) -> address:
+    return convert(shift(self.gauge_data[_gauge], 96), address)
+
+
+@view
+@external
+def gauge_version(_gauge: address) -> uint256:
+    return self.gauge_data[_gauge] % 2 ** 96

--- a/contracts/GaugeRegistry.vy
+++ b/contracts/GaugeRegistry.vy
@@ -18,7 +18,7 @@ factory: public(address)
 chain_id: public(uint256)
 
 gauge_count: public(uint256)
-gauge_list: public(address[MAX_UINT256])
+gauge_list: public(address[MAX_INT128])
 # [pool_address 20 bytes][version 12 bytes]
 gauge_data: HashMap[address, uint256]
 

--- a/contracts/GaugeRegistry.vy
+++ b/contracts/GaugeRegistry.vy
@@ -64,3 +64,8 @@ def pool_address(_gauge: address) -> address:
 @external
 def gauge_version(_gauge: address) -> uint256:
     return self.gauge_data[_gauge] % 2 ** 96
+
+
+@external
+def cache_factory():
+    self.factory = AddressProvider(ADDR_PROVIDER).get_address(3)

--- a/contracts/GaugeRegistry.vy
+++ b/contracts/GaugeRegistry.vy
@@ -28,7 +28,7 @@ gauge_data: HashMap[address, uint256]
 
 
 @external
-def __init__(_factory: address):
+def __init__():
     self.chain_id = chain.id
     self.factory = AddressProvider(ADDR_PROVIDER).get_address(3)  # metapool factory
 

--- a/contracts/GaugeRegistry.vy
+++ b/contracts/GaugeRegistry.vy
@@ -36,7 +36,7 @@ def _get_proxy_codehash(_impl_addr: Bytes[20]) -> bytes32:
 
 
 @external
-def register(_gauge: address, _version: uint256, _pool: address = ZERO_ADDRESS):
+def register(_gauge: address, _pool: address, _version: uint256):
     impl_addr: Bytes[20] = slice(
         convert(Factory(self.factory).gauge_implementation(), bytes32), 12, 20
     )

--- a/contracts/GaugeRegistry.vy
+++ b/contracts/GaugeRegistry.vy
@@ -13,11 +13,12 @@ interface Factory:
     def gauge_implementation() -> address: view
 
 
-ADDR_PROVIDER: constant(address) = 0x0000000022D53366457F9D5E68EC105046FC4383
-PROXY_PRE_BYTECODE: constant(Bytes[15]) = 0x366000600037611000600036600073
-PROXY_POST_BYTECODE: constant(Bytes[16]) = 0x5AF4602C57600080FD5B6110006000F3
+ADDR_PROVIDER: constant(address) = 0x0000000022D53366457F9d5E68Ec105046FC4383
+PROXY_PRE_BYTECODE: constant(Bytes[10]) = 0x363d3d373d3d3d363d73
+PROXY_POST_BYTECODE: constant(Bytes[15]) = 0x5af43d82803e903d91602b57fd5bf3
 
 
+factory: public(address)
 proxy_codehash: public(bytes32)
 chain_id: public(uint256)
 

--- a/contracts/GaugeRegistry.vy
+++ b/contracts/GaugeRegistry.vy
@@ -58,7 +58,7 @@ def register(_gauge: address, _pool: address, _version: uint256):
 @view
 @external
 def pool_address(_gauge: address) -> address:
-    return convert(shift(self.gauge_data[_gauge], 96), address)
+    return convert(shift(self.gauge_data[_gauge], -96), address)
 
 
 @view

--- a/contracts/GaugeRegistry.vy
+++ b/contracts/GaugeRegistry.vy
@@ -14,6 +14,7 @@ interface Factory:
 
 
 ADDR_PROVIDER: constant(address) = 0x0000000022D53366457F9d5E68Ec105046FC4383
+# See: https://eips.ethereum.org/EIPS/eip-1167
 PROXY_PRE_BYTECODE: constant(Bytes[10]) = 0x363d3d373d3d3d363d73
 PROXY_POST_BYTECODE: constant(Bytes[15]) = 0x5af43d82803e903d91602b57fd5bf3
 

--- a/contracts/testing/MockFactory.vy
+++ b/contracts/testing/MockFactory.vy
@@ -1,0 +1,18 @@
+# @version 0.2.15
+
+
+interface Initializable:
+    def initialize(): nonpayable
+
+
+gauge_implementation: public(address)
+
+
+@external
+def __init__(_gauge_impl):
+    self.gauge_implementation = _gauge_impl
+
+
+def deploy():
+    proxy: address = create_forwarder_to(self.gauge_implementation)
+    Initializable(proxy).initialize()

--- a/contracts/testing/MockFactory.vy
+++ b/contracts/testing/MockFactory.vy
@@ -9,10 +9,11 @@ gauge_implementation: public(address)
 
 
 @external
-def __init__(_gauge_impl):
+def __init__(_gauge_impl: address):
     self.gauge_implementation = _gauge_impl
 
 
+@external
 def deploy():
     proxy: address = create_forwarder_to(self.gauge_implementation)
     Initializable(proxy).initialize()

--- a/contracts/testing/MockGauge.vy
+++ b/contracts/testing/MockGauge.vy
@@ -1,0 +1,17 @@
+# @version 0.2.15
+
+
+ADDR_PROVIDER: constant(address) = 0x0000000022D53366457F9D5E68EC105046FC4383
+ETH_ADDR: constant(address) = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
+
+
+interface AddressProvider:
+    def get_address(_id: uint256) -> address: view
+
+interface GaugeRegistry:
+    def register(_gauge: address, _pool: address, _version: uint256): nonpayable
+
+
+def initialize():
+    gauge_registry: address = AddressProvider(ADDR_PROVIDER).get_address(5)
+    GaugeRegistry(gauge_registry).register(self, ETH_ADDR, 1)

--- a/contracts/testing/MockGauge.vy
+++ b/contracts/testing/MockGauge.vy
@@ -1,7 +1,7 @@
 # @version 0.2.15
 
 
-ADDR_PROVIDER: constant(address) = 0x0000000022D53366457F9D5E68EC105046FC4383
+ADDR_PROVIDER: constant(address) = 0x0000000022D53366457F9d5E68Ec105046FC4383
 ETH_ADDR: constant(address) = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
 
 
@@ -12,6 +12,7 @@ interface GaugeRegistry:
     def register(_gauge: address, _pool: address, _version: uint256): nonpayable
 
 
+@external
 def initialize():
     gauge_registry: address = AddressProvider(ADDR_PROVIDER).get_address(5)
     GaugeRegistry(gauge_registry).register(self, ETH_ADDR, 1)

--- a/tests/local/conftest.py
+++ b/tests/local/conftest.py
@@ -1,7 +1,8 @@
 import pytest
-from brownie import ERC20, ERC20NoReturn, ERC20ReturnFalse, cERC20, yERC20
+from brownie import ERC20, ERC20NoReturn, ERC20ReturnFalse, cERC20, compile_source, yERC20
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+ADDR_PROVIDER = "0x0000000022D53366457F9D5E68EC105046FC4383"
 
 RATE_METHOD_IDS = {
     "cERC20": cERC20.signatures["exchangeRateStored"],
@@ -317,3 +318,32 @@ def liquidity_gauge_meta(LiquidityGaugeMock, alice, gauge_controller, meta_lp_to
     gauge = LiquidityGaugeMock.deploy(meta_lp_token, {"from": alice})
     gauge_controller._set_gauge_type(gauge, 2, {"from": alice})
     yield gauge
+
+
+@pytest.fixture(scope="module")
+def gauge_implementation(alice, MockGauge, provider):
+    NewMockGauge = compile_source(
+        MockGauge._build["source"].replace(ADDR_PROVIDER, provider.address)
+    ).Vyper
+    return NewMockGauge.deploy({"from": alice})
+
+
+@pytest.fixture(scope="module")
+def mock_factory(alice, MockFactory, gauge_implementation, provider):
+    factory = MockFactory.deploy(gauge_implementation, {"from": alice})
+    # give the factory id # 3
+    while provider.max_id() < 4:
+        provider.add_new_id(factory, "Metapool Factory", {"from": alice})
+    return mock_factory
+
+
+@pytest.fixture(scope="module")
+def gauge_registry(alice, provider, GaugeRegistry):
+    NewGaugeRegistry = compile_source(
+        GaugeRegistry._build["source"].replace(ADDR_PROVIDER, provider.address)
+    ).Vyper
+    gauge_registry = NewGaugeRegistry.deploy({"from": alice})
+    # add to address provider at id = 5
+    while provider.max_id() < 6:
+        provider.add_new_id(gauge_registry, "Gauge Registry", {"from": alice})
+    return gauge_registry

--- a/tests/local/conftest.py
+++ b/tests/local/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from brownie import ERC20, ERC20NoReturn, ERC20ReturnFalse, cERC20, compile_source, yERC20
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
-ADDR_PROVIDER = "0x0000000022D53366457F9D5E68EC105046FC4383"
+ADDR_PROVIDER = "0x0000000022D53366457F9d5E68Ec105046FC4383"
 
 RATE_METHOD_IDS = {
     "cERC20": cERC20.signatures["exchangeRateStored"],
@@ -334,11 +334,11 @@ def mock_factory(alice, MockFactory, gauge_implementation, provider):
     # give the factory id # 3
     while provider.max_id() < 4:
         provider.add_new_id(factory, "Metapool Factory", {"from": alice})
-    return mock_factory
+    return factory
 
 
 @pytest.fixture(scope="module")
-def gauge_registry(alice, provider, GaugeRegistry):
+def gauge_registry(alice, provider, GaugeRegistry, mock_factory):
     NewGaugeRegistry = compile_source(
         GaugeRegistry._build["source"].replace(ADDR_PROVIDER, provider.address)
     ).Vyper

--- a/tests/local/unitary/GaugeRegistry/test_register.py
+++ b/tests/local/unitary/GaugeRegistry/test_register.py
@@ -8,3 +8,12 @@ def test_newly_deployed_gauge_auto_registers(alice, gauge_registry, mock_factory
     assert gauge_registry.gauge_list(0) == tx.new_contracts[0]
     assert gauge_registry.gauge_version(tx.new_contracts[0]) == 1
     assert gauge_registry.pool_address(tx.new_contracts[0]) == ETH_ADDRESS
+
+
+def test_admin_can_register_a_gauge(alice, gauge_registry):
+    gauge_registry.register(ETH_ADDRESS, ETH_ADDRESS, 42)
+
+    assert gauge_registry.gauge_count() == 1
+    assert gauge_registry.gauge_list(0) == ETH_ADDRESS
+    assert gauge_registry.gauge_version(ETH_ADDRESS) == 42
+    assert gauge_registry.pool_address(ETH_ADDRESS) == ETH_ADDRESS

--- a/tests/local/unitary/GaugeRegistry/test_register.py
+++ b/tests/local/unitary/GaugeRegistry/test_register.py
@@ -1,3 +1,4 @@
+import brownie
 from brownie import ETH_ADDRESS
 
 
@@ -11,9 +12,14 @@ def test_newly_deployed_gauge_auto_registers(alice, gauge_registry, mock_factory
 
 
 def test_admin_can_register_a_gauge(alice, gauge_registry):
-    gauge_registry.register(ETH_ADDRESS, ETH_ADDRESS, 42)
+    gauge_registry.register(ETH_ADDRESS, ETH_ADDRESS, 42, {"from": alice})
 
     assert gauge_registry.gauge_count() == 1
     assert gauge_registry.gauge_list(0) == ETH_ADDRESS
     assert gauge_registry.gauge_version(ETH_ADDRESS) == 42
     assert gauge_registry.pool_address(ETH_ADDRESS) == ETH_ADDRESS
+
+
+def test_guarded_register(bob, gauge_registry):
+    with brownie.reverts():
+        gauge_registry.register(ETH_ADDRESS, ETH_ADDRESS, 42, {"from": bob})

--- a/tests/local/unitary/GaugeRegistry/test_register.py
+++ b/tests/local/unitary/GaugeRegistry/test_register.py
@@ -1,0 +1,10 @@
+from brownie import ETH_ADDRESS
+
+
+def test_newly_deployed_gauge_auto_registers(alice, gauge_registry, mock_factory):
+    tx = mock_factory.deploy({"from": alice})
+
+    assert gauge_registry.gauge_count() == 1
+    assert gauge_registry.gauge_list(0) == tx.new_contracts[0]
+    assert gauge_registry.gauge_version(tx.new_contracts[0]) == 1
+    assert gauge_registry.pool_address(tx.new_contracts[0]) == ETH_ADDRESS


### PR DESCRIPTION
Gauge registry for tracking gauges deployed via the new curve factory.
Allows for gauges to auto-register themselves on initialization, given that they are minimal proxies for the gauge implementation which the Factory has in storage.

Features:
- Query the pool address of a gauge
- Query the gauge version
- Query the number of gauges registered
- Query the gauge addresses via index